### PR TITLE
Add initial voice mode scaffolding

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,10 +10,24 @@ from functools import wraps
 import firebase_admin
 from dotenv import load_dotenv
 from firebase_admin import auth, credentials, firestore
-from google.cloud.firestore_v1.base_query import FieldFilter
-from flask import Flask, jsonify, redirect, render_template, request, session, url_for, send_from_directory, Response, make_response
+from flask import (
+    Flask,
+    Response,
+    jsonify,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    send_from_directory,
+    session,
+    url_for,
+)
 from flask_cors import CORS
+from google.cloud.firestore_v1.base_query import FieldFilter
 from openai import OpenAI
+
+# Voice agent utilities
+from voice_agent import create_ephemeral_token
 
 # Load environment variables
 load_dotenv()
@@ -27,10 +41,14 @@ app.secret_key = os.environ.get(
 
 # Configure session
 # Set Secure=True for production (HTTPS), False for localhost (HTTP)
-is_production = os.environ.get("VERCEL") or os.environ.get("PRODUCTION") 
-app.config["SESSION_COOKIE_SECURE"] = is_production  # True for HTTPS, False for localhost
+is_production = os.environ.get("VERCEL") or os.environ.get("PRODUCTION")
+app.config["SESSION_COOKIE_SECURE"] = (
+    is_production  # True for HTTPS, False for localhost
+)
 app.config["SESSION_COOKIE_HTTPONLY"] = True
-app.config["SESSION_COOKIE_SAMESITE"] = "None" if is_production else "Lax"  # None for OAuth redirects in production
+app.config["SESSION_COOKIE_SAMESITE"] = (
+    "None" if is_production else "Lax"
+)  # None for OAuth redirects in production
 app.config["PERMANENT_SESSION_LIFETIME"] = 86400 * 7  # 7 days
 app.config["SESSION_PERMANENT"] = True
 
@@ -70,12 +88,12 @@ def to_json_filter(obj):
 
 
 # Favicon route - serve ICO file
-@app.route('/favicon.ico')
+@app.route("/favicon.ico")
 def favicon():
     return send_from_directory(
-        os.path.join(app.root_path, 'static/assets'),
-        'favicon.ico',
-        mimetype='image/x-icon'
+        os.path.join(app.root_path, "static/assets"),
+        "favicon.ico",
+        mimetype="image/x-icon",
     )
 
 
@@ -117,17 +135,32 @@ openai_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
 openai_client = OpenAI(api_key=openai_api_key)
 
 # Initialize billing system
-from billing import init_billing, get_subscription_manager, get_dodo_client, is_test_mode
+from billing import (
+    get_dodo_client,
+    get_subscription_manager,
+    init_billing,
+    is_test_mode,
+)
+
 init_billing(db)
 
 # Admin system disabled to prevent Firebase quota issues
-from admin import init_admin, admin_required, verify_admin_password, log_admin_login, AdminMetrics, ADMIN_SESSION_KEY
+from admin import (
+    ADMIN_SESSION_KEY,
+    AdminMetrics,
+    admin_required,
+    init_admin,
+    log_admin_login,
+    verify_admin_password,
+)
+
 init_admin(db)
 admin_metrics = AdminMetrics()
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 # Authentication decorators
 def login_required(f):
@@ -151,76 +184,95 @@ def login_required(f):
 
     return decorated_function
 
+
 def require_form_creation(f):
     """Decorator to check if user can create forms"""
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        if not hasattr(request, 'user'):
+        if not hasattr(request, "user"):
             return jsonify({"error": "Authentication required"}), 401
-        
+
         try:
             subscription_manager = get_subscription_manager()
-            can_create, error_message = subscription_manager.can_create_form(request.user["uid"])
-            
+            can_create, error_message = subscription_manager.can_create_form(
+                request.user["uid"]
+            )
+
             if not can_create:
-                return jsonify({
-                    "success": False,
-                    "error": error_message,
-                    "upgrade_required": True,
-                    "feature": "form_creation"
-                }), 403
-                
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": error_message,
+                            "upgrade_required": True,
+                            "feature": "form_creation",
+                        }
+                    ),
+                    403,
+                )
+
             return f(*args, **kwargs)
         except Exception as e:
             logger.error(f"Error checking form creation limits: {str(e)}")
             # Allow on error to avoid breaking functionality
             return f(*args, **kwargs)
-    
+
     return decorated_function
+
 
 def require_conversation_limit(f):
     """Decorator to check conversation limits"""
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         # For conversation endpoints, we need to check the form owner, not the respondent
         data = request.get_json() if request.is_json else {}
         form_id = data.get("form_id") or kwargs.get("form_id")
-        
+
         if not form_id:
             return f(*args, **kwargs)
-        
+
         try:
             # Get form owner
             form_doc = db.collection("forms").document(form_id).get()
             if not form_doc.exists:
                 return jsonify({"error": "Form not found"}), 404
-                
+
             form_data = form_doc.to_dict()
             form_owner_id = form_data.get("creator_id")
-            
+
             if not form_owner_id:
                 return f(*args, **kwargs)
-            
+
             subscription_manager = get_subscription_manager()
-            can_start, error_message = subscription_manager.can_start_conversation(form_owner_id)
-            
+            can_start, error_message = subscription_manager.can_start_conversation(
+                form_owner_id
+            )
+
             if not can_start:
-                return jsonify({
-                    "error": "Conversation limit reached",
-                    "message": "This survey has reached its monthly conversation limit. The survey owner needs to upgrade their plan.",
-                    "upgrade_required": True
-                }), 403
-            
+                return (
+                    jsonify(
+                        {
+                            "error": "Conversation limit reached",
+                            "message": "This survey has reached its monthly conversation limit. The survey owner needs to upgrade their plan.",
+                            "upgrade_required": True,
+                        }
+                    ),
+                    403,
+                )
+
             # If allowed, increment counter and proceed
             subscription_manager.increment_conversation_count(form_owner_id)
             return f(*args, **kwargs)
-            
+
         except Exception as e:
             logger.error(f"Error checking conversation limits: {str(e)}")
             # Allow on error to avoid breaking functionality
             return f(*args, **kwargs)
-    
+
     return decorated_function
+
 
 # Form inference functions
 def create_inference_prompt(input_text):
@@ -239,7 +291,7 @@ REASONING PROCESS (Chain-of-Thought):
 
 OUTPUT FORMAT (JSON only, no additional text):
 {{
-  "title": "Form Title (concise, descriptive)", 
+  "title": "Form Title (concise, descriptive)",
   "questions": [
     {{
       "text": "Question text",
@@ -253,7 +305,7 @@ OUTPUT FORMAT (JSON only, no additional text):
 QUESTION TYPES:
 - text: Open-ended text responses
 - multiple_choice: Select one from predefined options (include "Other" and "Prefer not to say" when appropriate)
-- yes_no: Simple yes/no questions  
+- yes_no: Simple yes/no questions
 - number: Numeric input (age, quantity, etc.)
 - rating: 1-5 or 1-10 scale ratings
 
@@ -280,7 +332,7 @@ OUTPUT:
     }},
     {{
       "text": "What is your favorite type of coffee drink?",
-      "type": "multiple_choice", 
+      "type": "multiple_choice",
       "options": ["Espresso", "Americano", "Latte", "Cappuccino", "Cold Brew", "Frappuccino", "Other"],
       "enabled": true
     }},
@@ -450,9 +502,9 @@ def home():
     # Check if user is authenticated
     if session.get("authenticated") and session.get("user_id"):
         return redirect(url_for("create_form"))
-    
+
     # Show landing page for unauthenticated users
-    return render_template('index.html')
+    return render_template("index.html")
 
 
 # A/B test conversion tracking removed
@@ -471,15 +523,18 @@ def test_session():
         }
     )
 
+
 @app.route("/test-auth", methods=["GET", "POST"])
 def test_auth():
     """Test auth endpoint to debug Vercel protection"""
     logger.info(f"Test auth endpoint - Method: {request.method}")
-    return jsonify({
-        "message": "Auth endpoint working",
-        "method": request.method,
-        "timestamp": datetime.now().isoformat()
-    })
+    return jsonify(
+        {
+            "message": "Auth endpoint working",
+            "method": request.method,
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
 
 
 @app.route("/test-openai")
@@ -538,17 +593,25 @@ def test_openai():
 def google_auth():
     """Handle Google Firebase authentication with quota-safe fallback"""
     logger.info(f"=== GOOGLE AUTH REQUEST START === Method: {request.method}")
-    
+
     # Handle GET request for debugging
     if request.method == "GET":
         logger.info("GET request received - this should be a POST request")
-        return jsonify({"error": "This endpoint requires POST method", "method_received": request.method}), 405
-    
+        return (
+            jsonify(
+                {
+                    "error": "This endpoint requires POST method",
+                    "method_received": request.method,
+                }
+            ),
+            405,
+        )
+
     try:
         # Get the ID token from the request
         data = request.get_json()
         logger.info(f"Request data received: {data is not None}")
-        
+
         if not data or "idToken" not in data:
             logger.error("No ID token in request data")
             return jsonify({"error": "ID token is required"}), 400
@@ -561,47 +624,54 @@ def google_auth():
         try:
             # Set a shorter timeout to prevent 5-minute hangs
             import signal
+
             def timeout_handler(signum, frame):
                 raise TimeoutError("Firebase verification timeout")
-            
+
             signal.signal(signal.SIGALRM, timeout_handler)
             signal.alarm(10)  # 10 second timeout
-            
+
             decoded_token = auth.verify_id_token(id_token)
             signal.alarm(0)  # Cancel timeout
-            logger.info(f"Token verification successful, user: {decoded_token.get('email', 'unknown')}")
+            logger.info(
+                f"Token verification successful, user: {decoded_token.get('email', 'unknown')}"
+            )
 
             # Extract user information
             user_id = decoded_token["uid"]
             email = decoded_token.get("email", "")
             name = decoded_token.get("name", "")
-            
+
         except (TimeoutError, Exception) as e:
             signal.alarm(0)  # Cancel timeout
-            logger.warning(f"Firebase verification failed ({str(e)}), using token-based fallback")
-            
+            logger.warning(
+                f"Firebase verification failed ({str(e)}), using token-based fallback"
+            )
+
             # Fallback: decode JWT without verification for quota issues
             import base64
             import json
-            
+
             # Split the JWT into parts
-            parts = id_token.split('.')
+            parts = id_token.split(".")
             if len(parts) != 3:
                 raise ValueError("Invalid JWT format")
-            
+
             # Decode the payload (add padding if needed)
             payload = parts[1]
-            payload += '=' * (4 - len(payload) % 4)  # Add padding
+            payload += "=" * (4 - len(payload) % 4)  # Add padding
             decoded_payload = base64.urlsafe_b64decode(payload)
             token_data = json.loads(decoded_payload)
-            
-            logger.info(f"Using JWT fallback for user: {token_data.get('email', 'unknown')}")
-            
+
+            logger.info(
+                f"Using JWT fallback for user: {token_data.get('email', 'unknown')}"
+            )
+
             # Extract user information from JWT payload
             user_id = token_data.get("sub", "")  # 'sub' is the user ID in JWT
             email = token_data.get("email", "")
             name = token_data.get("name", "")
-            
+
             if not user_id or not email:
                 raise ValueError("Invalid token payload")
 
@@ -620,21 +690,25 @@ def google_auth():
                 }
                 user_ref.set(user_data)
                 logger.info(f"Created new user: {email}")
-                
+
                 # Send welcome email to new user
                 try:
                     email_result = email_service.send_welcome_email(email, name)
                     if email_result.get("success"):
                         logger.info(f"Welcome email sent to {email}")
                     else:
-                        logger.warning(f"Failed to send welcome email to {email}: {email_result.get('error')}")
+                        logger.warning(
+                            f"Failed to send welcome email to {email}: {email_result.get('error')}"
+                        )
                 except Exception as e:
                     logger.error(f"Error sending welcome email to {email}: {str(e)}")
             else:
                 logger.info(f"User login: {email}")
         except Exception as firestore_error:
             # If Firestore is also hitting quota, continue with session anyway
-            logger.warning(f"Firestore operation failed ({str(firestore_error)}), continuing with session")
+            logger.warning(
+                f"Firestore operation failed ({str(firestore_error)}), continuing with session"
+            )
 
         # Store user session with permanence
         session.permanent = True
@@ -659,6 +733,7 @@ def google_auth():
     except Exception as e:
         logger.error(f"=== GOOGLE AUTH ERROR === {str(e)}")
         import traceback
+
         logger.error(f"Full traceback: {traceback.format_exc()}")
         return jsonify({"error": "Authentication failed", "details": str(e)}), 401
 
@@ -709,7 +784,11 @@ def dashboard():
         # Get user's forms with response counts
         try:
             # Try to get forms ordered by creation date (newest first) - requires composite index
-            forms_ref = db.collection("forms").where(filter=FieldFilter("creator_id", "==", user_id)).order_by("created_at", direction=firestore.Query.DESCENDING)
+            forms_ref = (
+                db.collection("forms")
+                .where(filter=FieldFilter("creator_id", "==", user_id))
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
+            )
             forms = []
             for doc in forms_ref.stream():
                 form_data = doc.to_dict()
@@ -717,7 +796,9 @@ def dashboard():
 
                 # Count responses for this form more efficiently
                 # Use limit to avoid loading all documents
-                responses_ref = db.collection("responses").where(filter=FieldFilter("form_id", "==", doc.id))
+                responses_ref = db.collection("responses").where(
+                    filter=FieldFilter("form_id", "==", doc.id)
+                )
                 response_docs = responses_ref.limit(100).stream()
                 response_count = sum(1 for _ in response_docs)
                 # If we hit the limit, show 100+
@@ -728,8 +809,12 @@ def dashboard():
                 forms.append(form_data)
         except Exception as index_error:
             # Fallback: Get forms without ordering if composite index doesn't exist yet
-            print(f"Composite index not available, falling back to unordered query: {index_error}")
-            forms_ref = db.collection("forms").where(filter=FieldFilter("creator_id", "==", user_id))
+            print(
+                f"Composite index not available, falling back to unordered query: {index_error}"
+            )
+            forms_ref = db.collection("forms").where(
+                filter=FieldFilter("creator_id", "==", user_id)
+            )
             forms = []
             for doc in forms_ref.stream():
                 form_data = doc.to_dict()
@@ -737,7 +822,9 @@ def dashboard():
 
                 # Count responses for this form more efficiently
                 # Use limit to avoid loading all documents
-                responses_ref = db.collection("responses").where(filter=FieldFilter("form_id", "==", doc.id))
+                responses_ref = db.collection("responses").where(
+                    filter=FieldFilter("form_id", "==", doc.id)
+                )
                 response_docs = responses_ref.limit(100).stream()
                 response_count = sum(1 for _ in response_docs)
                 # If we hit the limit, show 100+
@@ -746,9 +833,9 @@ def dashboard():
                 form_data["response_count"] = response_count
 
                 forms.append(form_data)
-            
+
             # Sort in Python as fallback (less efficient but works without index)
-            forms.sort(key=lambda x: x.get('created_at', datetime.min), reverse=True)
+            forms.sort(key=lambda x: x.get("created_at", datetime.min), reverse=True)
 
         return render_template("dashboard.html", forms=forms, user=request.user)
 
@@ -768,17 +855,23 @@ def billing():
 
 
 @app.route("/api/user")
-@login_required 
+@login_required
 def check_user_session():
     """Check if user session is valid - lightweight endpoint"""
     try:
-        return jsonify({
-            "authenticated": True,
-            "user_id": request.user["uid"], 
-            "email": request.user["email"]
-        }), 200
+        return (
+            jsonify(
+                {
+                    "authenticated": True,
+                    "user_id": request.user["uid"],
+                    "email": request.user["email"],
+                }
+            ),
+            200,
+        )
     except Exception as e:
         return jsonify({"error": "Session invalid"}), 401
+
 
 @app.route("/api/user/profile")
 @login_required
@@ -1023,7 +1116,9 @@ def infer_form():
                     "title": inferred_form["title"],
                     "questions": inferred_form["questions"],
                     "demographics": inferred_form.get("demographics", {}),
-                    "profile_data": inferred_form.get("profile_data", {}),  # NEW: Profile data section
+                    "profile_data": inferred_form.get(
+                        "profile_data", {}
+                    ),  # NEW: Profile data section
                     "bot_context": "",  # Empty by default in inference, can be added in editing
                     "creator_id": user_id,
                     "active": False,  # Key field - survey is inactive
@@ -1113,16 +1208,18 @@ def infer_form():
 
 def refine_user_prompt(original_prompt, max_retries=2):
     """Use OpenAI GPT-4o-mini to refine and improve user prompts for form generation"""
-    
+
     api_key = os.environ.get("OPENAI_API_KEY", "").strip()
     if not api_key:
         logger.error("OPENAI_API_KEY environment variable not found!")
         return None, "OpenAI API key not configured"
-    
+
     for attempt in range(max_retries + 1):
         try:
-            logger.info(f"Prompt refinement attempt {attempt + 1} for: {original_prompt[:100]}...")
-            
+            logger.info(
+                f"Prompt refinement attempt {attempt + 1} for: {original_prompt[:100]}..."
+            )
+
             # Create refinement prompt
             refinement_prompt = f"""
 You are a prompt optimization specialist. Your job is to take a user's rough description and turn it into a clear, well-structured prompt that will be fed to a form-generation AI.
@@ -1151,42 +1248,49 @@ Original user input:
 "{original_prompt}"
 
 Refined prompt:"""
-            
+
             # Generate response using OpenAI client
             response = openai_client.chat.completions.create(
                 model="gpt-4o-mini",
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are a prompt optimization specialist. Your job is to refine user inputs into better prompts that will be fed to a form-generation AI. You are NOT generating forms yourself - just writing better prompts for another AI to use. Return only the refined prompt text, no explanations."
+                        "content": "You are a prompt optimization specialist. Your job is to refine user inputs into better prompts that will be fed to a form-generation AI. You are NOT generating forms yourself - just writing better prompts for another AI to use. Return only the refined prompt text, no explanations.",
                     },
-                    {"role": "user", "content": refinement_prompt}
+                    {"role": "user", "content": refinement_prompt},
                 ],
                 temperature=0.1,  # Low temperature for clarity and consistency
                 max_tokens=1000,
             )
-            
+
             refined_text = response.choices[0].message.content.strip()
-            
+
             # Basic validation of refined text
             if len(refined_text) < 10:
-                logger.warning(f"Attempt {attempt + 1} produced very short output: {refined_text}")
+                logger.warning(
+                    f"Attempt {attempt + 1} produced very short output: {refined_text}"
+                )
                 if attempt == max_retries:
                     return None, "Refined prompt too short"
                 continue
-            
+
             # Remove quotes if the AI wrapped the response in quotes
             if refined_text.startswith('"') and refined_text.endswith('"'):
                 refined_text = refined_text[1:-1]
-            
+
             logger.info(f"Successfully refined prompt on attempt {attempt + 1}")
             return refined_text, None
-            
+
         except Exception as e:
-            logger.error(f"Error during prompt refinement attempt {attempt + 1}: {str(e)}")
+            logger.error(
+                f"Error during prompt refinement attempt {attempt + 1}: {str(e)}"
+            )
             if attempt == max_retries:
-                return None, f"Failed to refine prompt after {max_retries + 1} attempts: {str(e)}"
-    
+                return (
+                    None,
+                    f"Failed to refine prompt after {max_retries + 1} attempts: {str(e)}",
+                )
+
     return None, "Unexpected error in prompt refinement"
 
 
@@ -1195,12 +1299,12 @@ Refined prompt:"""
 def refine_prompt():
     """
     Refine user prompt to be clearer and more structured for form generation
-    
+
     Expected JSON payload:
     {
         "prompt": "original user text"
     }
-    
+
     Returns:
     {
         "success": true,
@@ -1211,32 +1315,60 @@ def refine_prompt():
         # Get request data
         data = request.get_json()
         if not data or "prompt" not in data:
-            return jsonify({"success": False, "error": "Prompt is required in request body"}), 400
-        
+            return (
+                jsonify(
+                    {"success": False, "error": "Prompt is required in request body"}
+                ),
+                400,
+            )
+
         original_prompt = data["prompt"].strip()
-        
+
         # Basic validation
         if len(original_prompt) < 5:
-            return jsonify({"success": False, "error": "Prompt too short to refine"}), 400
-        
+            return (
+                jsonify({"success": False, "error": "Prompt too short to refine"}),
+                400,
+            )
+
         if len(original_prompt) > 5000:
-            return jsonify({"success": False, "error": "Prompt too long to refine"}), 400
-        
-        logger.info(f"Prompt refinement requested by user {request.user['uid']} for: {original_prompt[:100]}...")
-        
+            return (
+                jsonify({"success": False, "error": "Prompt too long to refine"}),
+                400,
+            )
+
+        logger.info(
+            f"Prompt refinement requested by user {request.user['uid']} for: {original_prompt[:100]}..."
+        )
+
         # Call OpenAI to refine the prompt
         refined_text, error = refine_user_prompt(original_prompt)
-        
+
         if refined_text:
-            logger.info(f"Successfully refined prompt from {len(original_prompt)} to {len(refined_text)} characters")
+            logger.info(
+                f"Successfully refined prompt from {len(original_prompt)} to {len(refined_text)} characters"
+            )
             return jsonify({"success": True, "refined_prompt": refined_text})
         else:
             logger.error(f"Prompt refinement failed: {error}")
-            return jsonify({"success": False, "error": error or "Failed to refine prompt"}), 500
-            
+            return (
+                jsonify(
+                    {"success": False, "error": error or "Failed to refine prompt"}
+                ),
+                500,
+            )
+
     except Exception as e:
         logger.error(f"Unexpected error in /api/refine_prompt: {str(e)}")
-        return jsonify({"success": False, "error": "Internal server error during prompt refinement"}), 500
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Internal server error during prompt refinement",
+                }
+            ),
+            500,
+        )
 
 
 @app.route("/create-form")
@@ -1269,40 +1401,48 @@ def why():
     """Why Barmuda page - explains the science and research behind conversational surveys"""
     return render_template("why.html")
 
+
 @app.route("/guides")
 def guides():
     """Guides hub - SEO content for AI user interviews and conversational surveys"""
     return render_template("guides.html")
+
 
 @app.route("/guides/ai-user-interviews")
 def ai_user_interviews_guide():
     """Complete Guide to AI User Interviews - hero SEO content"""
     return render_template("guides/ai-user-interviews.html")
 
+
 @app.route("/guides/conversational-vs-traditional-surveys")
 def conversational_vs_traditional():
     """Conversational vs Traditional Surveys comparison guide"""
     return render_template("guides/conversational-vs-traditional.html")
+
 
 @app.route("/financial-consultants")
 def financial_consultants():
     """Landing page for Financial Consultants persona"""
     return render_template("financial-consultants.html")
 
+
 @app.route("/therapists")
 def therapists():
     """Landing page for Mental Health Professionals persona"""
     return render_template("therapists.html")
+
 
 @app.route("/market-research")
 def market_research():
     """Landing page for Market Researchers persona"""
     return render_template("market-research.html")
 
+
 @app.route("/vs-typeform")
 def vs_typeform():
     """Barmuda vs Typeform comparison page"""
     return render_template("comparisons/vs-typeform.html")
+
 
 @app.route("/vs-google-forms")
 def vs_google_forms():
@@ -1314,27 +1454,27 @@ def vs_google_forms():
 @app.route("/robots.txt")
 def robots_txt():
     """Serve robots.txt for search engines and AI crawlers"""
-    return app.send_static_file('robots.txt')
+    return app.send_static_file("robots.txt")
 
 
 @app.route("/llms.txt")
 def llms_txt():
     """Serve llms.txt for AI/LLM training and knowledge"""
-    return app.send_static_file('llms.txt')
+    return app.send_static_file("llms.txt")
 
 
 @app.route("/sitemap.xml")
 def sitemap_xml():
     """Serve sitemap.xml for search engines"""
-    return app.send_static_file('sitemap.xml')
+    return app.send_static_file("sitemap.xml")
 
 
 @app.route("/sw.js")
 def service_worker():
     """Serve service worker for PWA and caching"""
-    response = app.send_static_file('sw.js')
-    response.headers['Content-Type'] = 'application/javascript'
-    response.headers['Service-Worker-Allowed'] = '/'
+    response = app.send_static_file("sw.js")
+    response.headers["Content-Type"] = "application/javascript"
+    response.headers["Service-Worker-Allowed"] = "/"
     return response
 
 
@@ -1442,18 +1582,39 @@ def save_form():
                         400,
                     )
 
+        # Determine mode and voice settings
+        mode = form_data.get("mode", "chat")
+        if mode not in ["chat", "voice"]:
+            return jsonify({"success": False, "error": "Invalid mode"}), 400
+
+        voice_settings = form_data.get("voice_settings") if mode == "voice" else {}
+        if mode == "voice":
+            if (
+                not voice_settings
+                or not voice_settings.get("language")
+                or not voice_settings.get("voice_id")
+            ):
+                return (
+                    jsonify({"success": False, "error": "Voice settings required"}),
+                    400,
+                )
+
         # Prepare form document
         form_document = {
             "title": form_data["title"],
             "questions": form_data["questions"],
             "demographics": form_data.get("demographics", {}),
-            "profile_data": form_data.get("profile_data", {}),  # NEW: Profile data section
+            "profile_data": form_data.get(
+                "profile_data", {}
+            ),  # NEW: Profile data section
             "bot_context": form_data.get("bot_context", ""),
             "creator_id": user_id,
             "created_at": datetime.utcnow().isoformat(),
             "updated_at": datetime.utcnow().isoformat(),
             "status": "active",
             "response_count": 0,
+            "mode": mode,
+            "voice_settings": voice_settings,
         }
 
         logger.info(f"Saving form '{form_data['title']}' for user {user_id}")
@@ -1574,18 +1735,39 @@ def update_form(form_id):
                 400,
             )
 
+        # Determine mode and voice settings
+        mode = form_data.get("mode", existing_form.get("mode", "chat"))
+        if mode not in ["chat", "voice"]:
+            return jsonify({"success": False, "error": "Invalid mode"}), 400
+
+        voice_settings = form_data.get("voice_settings") if mode == "voice" else {}
+        if mode == "voice":
+            if (
+                not voice_settings
+                or not voice_settings.get("language")
+                or not voice_settings.get("voice_id")
+            ):
+                return (
+                    jsonify({"success": False, "error": "Voice settings required"}),
+                    400,
+                )
+
         # Prepare update document
         update_document = {
             "title": form_data["title"],
             "questions": form_data["questions"],
             "demographics": form_data.get("demographics", {}),
-            "profile_data": form_data.get("profile_data", {}),  # NEW: Profile data section
+            "profile_data": form_data.get(
+                "profile_data", {}
+            ),  # NEW: Profile data section
             "bot_context": form_data.get("bot_context", ""),
             "active": form_data.get(
                 "active", existing_form.get("active", False)
             ),  # Handle activation
             "last_modified": datetime.utcnow(),
             "updated_at": datetime.utcnow().isoformat(),
+            "mode": mode,
+            "voice_settings": voice_settings,
         }
 
         # If activating for the first time, generate share URL
@@ -1604,9 +1786,7 @@ def update_form(form_id):
 
         # Get final share URL (either existing or newly generated)
         updated_doc = form_ref.get().to_dict()
-        share_url = updated_doc.get(
-            "share_url", f"https://barmuda.in/form/{form_id}"
-        )
+        share_url = updated_doc.get("share_url", f"https://barmuda.in/form/{form_id}")
 
         return (
             jsonify(
@@ -1676,7 +1856,9 @@ def get_form(form_id):
                         "title": form_data.get("title"),
                         "questions": form_data.get("questions", []),
                         "demographics": form_data.get("demographics", {}),
-                        "profile_data": form_data.get("profile_data", {}),  # NEW: Include in response
+                        "profile_data": form_data.get(
+                            "profile_data", {}
+                        ),  # NEW: Include in response
                     },
                     "metadata": {
                         "form_id": form_id,
@@ -1715,41 +1897,44 @@ def health_check():
 # BILLING & SUBSCRIPTION ROUTES
 # ================================
 
+
 @app.route("/api/billing/plans")
 def get_pricing_plans():
     """Get available pricing plans"""
     try:
         subscription_manager = get_subscription_manager()
-        
-        return jsonify({
-            "success": True,
-            "plans": {
-                "free": {
-                    "name": "Free",
-                    "price": 0,
-                    "currency": "USD",
-                    "features": subscription_manager.PLAN_LIMITS["free"]
+
+        return jsonify(
+            {
+                "success": True,
+                "plans": {
+                    "free": {
+                        "name": "Free",
+                        "price": 0,
+                        "currency": "USD",
+                        "features": subscription_manager.PLAN_LIMITS["free"],
+                    },
+                    "starter": {
+                        "name": "Starter",
+                        "price": 19,
+                        "currency": "USD",
+                        "features": subscription_manager.PLAN_LIMITS["starter"],
+                    },
+                    "pro": {
+                        "name": "Pro",
+                        "price": 49,
+                        "currency": "USD",
+                        "features": subscription_manager.PLAN_LIMITS["pro"],
+                    },
+                    "business": {
+                        "name": "Business",
+                        "price": "Custom",
+                        "currency": "USD",
+                        "features": subscription_manager.PLAN_LIMITS["business"],
+                    },
                 },
-                "starter": {
-                    "name": "Starter",
-                    "price": 19,
-                    "currency": "USD",
-                    "features": subscription_manager.PLAN_LIMITS["starter"]
-                },
-                "pro": {
-                    "name": "Pro", 
-                    "price": 49,
-                    "currency": "USD",
-                    "features": subscription_manager.PLAN_LIMITS["pro"]
-                },
-                "business": {
-                    "name": "Business",
-                    "price": "Custom",
-                    "currency": "USD",
-                    "features": subscription_manager.PLAN_LIMITS["business"]
-                }
             }
-        })
+        )
     except Exception as e:
         logger.error(f"Error getting pricing plans: {str(e)}")
         return jsonify({"success": False, "error": "Failed to get pricing plans"}), 500
@@ -1762,30 +1947,48 @@ def get_user_subscription():
     try:
         user_id = request.user["uid"]
         subscription_manager = get_subscription_manager()
-        
+
         subscription = subscription_manager.get_user_subscription(user_id)
         usage = subscription_manager.get_user_usage(user_id)
-        
+
         # Get plan limits for context
         plan = subscription.get("plan", "free")
-        limits = subscription_manager.PLAN_LIMITS.get(plan, subscription_manager.PLAN_LIMITS["free"])
-        
-        return jsonify({
-            "success": True,
-            "subscription": subscription,
-            "usage": usage,
-            "limits": limits,
-            "plan_features": {
-                "remove_branding": subscription_manager.has_feature(user_id, "remove_branding"),
-                "custom_widget_colors": subscription_manager.has_feature(user_id, "custom_widget_colors"),
-                "template_library": subscription_manager.has_feature(user_id, "template_library"),
-                "word_cloud": subscription_manager.has_feature(user_id, "word_cloud"),
-                "advanced_export": subscription_manager.has_feature(user_id, "advanced_export"),
-                "priority_support": subscription_manager.has_feature(user_id, "priority_support"),
-                "team_members": subscription_manager.has_feature(user_id, "team_members")
+        limits = subscription_manager.PLAN_LIMITS.get(
+            plan, subscription_manager.PLAN_LIMITS["free"]
+        )
+
+        return jsonify(
+            {
+                "success": True,
+                "subscription": subscription,
+                "usage": usage,
+                "limits": limits,
+                "plan_features": {
+                    "remove_branding": subscription_manager.has_feature(
+                        user_id, "remove_branding"
+                    ),
+                    "custom_widget_colors": subscription_manager.has_feature(
+                        user_id, "custom_widget_colors"
+                    ),
+                    "template_library": subscription_manager.has_feature(
+                        user_id, "template_library"
+                    ),
+                    "word_cloud": subscription_manager.has_feature(
+                        user_id, "word_cloud"
+                    ),
+                    "advanced_export": subscription_manager.has_feature(
+                        user_id, "advanced_export"
+                    ),
+                    "priority_support": subscription_manager.has_feature(
+                        user_id, "priority_support"
+                    ),
+                    "team_members": subscription_manager.has_feature(
+                        user_id, "team_members"
+                    ),
+                },
             }
-        })
-        
+        )
+
     except Exception as e:
         logger.error(f"Error getting user subscription: {str(e)}")
         return jsonify({"success": False, "error": "Failed to get subscription"}), 500
@@ -1798,43 +2001,57 @@ def create_subscription():
     try:
         data = request.get_json()
         plan = data.get("plan")
-        
+
         if not plan or plan not in ["starter", "pro", "business"]:
             return jsonify({"success": False, "error": "Invalid plan"}), 400
-        
+
         user_id = request.user["uid"]
         user_email = request.user["email"]
-        
+
         # Create Dodo payment link
         dodo_client = get_dodo_client()
         if not dodo_client:
-            return jsonify({"success": False, "error": "Payment system not configured"}), 500
-        
+            return (
+                jsonify({"success": False, "error": "Payment system not configured"}),
+                500,
+            )
+
         success_url = f"https://barmuda.in/dashboard?payment=success&plan={plan}"
         cancel_url = f"https://barmuda.in/pricing?payment=cancelled"
-        
+
         result = dodo_client.create_subscription_link(
             plan=plan,
             customer_email=user_email,
             success_url=success_url,
-            cancel_url=cancel_url
+            cancel_url=cancel_url,
         )
-        
+
         if result["success"]:
-            return jsonify({
-                "success": True,
-                "checkout_url": result.get("checkout_url") or result.get("data", {}).get("payment_link"),
-                "plan": plan
-            })
+            return jsonify(
+                {
+                    "success": True,
+                    "checkout_url": result.get("checkout_url")
+                    or result.get("data", {}).get("payment_link"),
+                    "plan": plan,
+                }
+            )
         else:
-            return jsonify({
-                "success": False,
-                "error": f"Failed to create payment link: {result['error']}"
-            }), 500
-            
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": f"Failed to create payment link: {result['error']}",
+                    }
+                ),
+                500,
+            )
+
     except Exception as e:
         logger.error(f"Error creating subscription: {str(e)}")
-        return jsonify({"success": False, "error": "Failed to create subscription"}), 500
+        return (
+            jsonify({"success": False, "error": "Failed to create subscription"}),
+            500,
+        )
 
 
 @app.route("/api/billing/cancel", methods=["POST"])
@@ -1844,29 +2061,33 @@ def cancel_subscription():
     try:
         user_id = request.user["uid"]
         subscription_manager = get_subscription_manager()
-        
+
         subscription = subscription_manager.get_user_subscription(user_id)
         dodo_subscription_id = subscription.get("dodo_subscription_id")
-        
+
         if dodo_subscription_id:
             # Cancel with Dodo
             dodo_client = get_dodo_client()
             if dodo_client:
                 result = dodo_client.cancel_subscription(dodo_subscription_id)
                 if not result["success"]:
-                    logger.warning(f"Failed to cancel Dodo subscription: {result['error']}")
-        
+                    logger.warning(
+                        f"Failed to cancel Dodo subscription: {result['error']}"
+                    )
+
         # Update local subscription
         subscription_manager.cancel_subscription(user_id)
-        
-        return jsonify({
-            "success": True,
-            "message": "Subscription cancelled successfully"
-        })
-        
+
+        return jsonify(
+            {"success": True, "message": "Subscription cancelled successfully"}
+        )
+
     except Exception as e:
         logger.error(f"Error cancelling subscription: {str(e)}")
-        return jsonify({"success": False, "error": "Failed to cancel subscription"}), 500
+        return (
+            jsonify({"success": False, "error": "Failed to cancel subscription"}),
+            500,
+        )
 
 
 @app.route("/api/billing/invoices")
@@ -1876,14 +2097,11 @@ def get_user_invoices():
     try:
         user_id = request.user["uid"]
         subscription_manager = get_subscription_manager()
-        
+
         invoices = subscription_manager.get_user_invoices(user_id)
-        
-        return jsonify({
-            "success": True,
-            "invoices": invoices
-        })
-        
+
+        return jsonify({"success": True, "invoices": invoices})
+
     except Exception as e:
         logger.error(f"Error getting invoices: {str(e)}")
         return jsonify({"success": False, "error": "Failed to get invoices"}), 500
@@ -1899,103 +2117,114 @@ def grandfather_user_admin():
         admin_emails = ["krishnaaimaddy@gmail.com", "admin@barmuda.in"]
         if request.user["email"] not in admin_emails:
             return jsonify({"success": False, "error": "Admin access required"}), 403
-        
+
         data = request.get_json()
         target_email = data.get("email")
         plan_type = data.get("plan_type", "pro")  # 'pro' or 'business'
-        
+
         if not target_email:
             return jsonify({"success": False, "error": "User email is required"}), 400
-        
+
         # Find user by email
         users_ref = db.collection("users").where("email", "==", target_email)
         users = list(users_ref.stream())
-        
+
         if not users:
             return jsonify({"success": False, "error": "User not found"}), 404
-        
+
         user_id = users[0].id
-        
+
         # Grandfather the user
         subscription_manager = get_subscription_manager()
         success = subscription_manager.grandfather_user(user_id, plan_type)
-        
+
         if success:
-            return jsonify({
-                "success": True,
-                "message": f"User {target_email} successfully grandfathered to {plan_type} plan"
-            })
+            return jsonify(
+                {
+                    "success": True,
+                    "message": f"User {target_email} successfully grandfathered to {plan_type} plan",
+                }
+            )
         else:
-            return jsonify({
-                "success": False,
-                "error": "Failed to grandfather user"
-            }), 500
-            
+            return (
+                jsonify({"success": False, "error": "Failed to grandfather user"}),
+                500,
+            )
+
     except Exception as e:
         logger.error(f"Error in admin grandfather endpoint: {str(e)}")
         return jsonify({"success": False, "error": str(e)}), 500
+
 
 @app.route("/webhooks/dodo", methods=["POST"])
 def dodo_webhook():
     """Handle Dodo payment webhooks with correct signature verification"""
     try:
         # Get webhook headers - check both possible header formats
-        signature = request.headers.get("webhook-signature") or request.headers.get("dodo-signature") or request.headers.get("X-Signature")
+        signature = (
+            request.headers.get("webhook-signature")
+            or request.headers.get("dodo-signature")
+            or request.headers.get("X-Signature")
+        )
         webhook_id = request.headers.get("webhook-id")
         webhook_timestamp = request.headers.get("webhook-timestamp")
         webhook_secret = os.environ.get("DODO_WEBHOOK_SECRET")
-        
+
         if not webhook_secret or not signature:
             logger.warning("Missing webhook signature or secret")
             return jsonify({"error": "Unauthorized"}), 401
-        
+
         payload = request.get_data(as_text=True)
         dodo_client = get_dodo_client()
-        
-        if not dodo_client or not dodo_client.verify_webhook(payload, signature, webhook_secret, webhook_timestamp, webhook_id):
+
+        if not dodo_client or not dodo_client.verify_webhook(
+            payload, signature, webhook_secret, webhook_timestamp, webhook_id
+        ):
             logger.warning("Invalid webhook signature")
             return jsonify({"error": "Invalid signature"}), 401
-        
+
         # Process webhook event
         event_data = request.get_json()
         event_type = event_data.get("type")
         event_object = event_data.get("data", {})
-        
+
         subscription_manager = get_subscription_manager()
-        
+
         if event_type == "subscription.created":
             # New subscription created
             customer_email = event_object.get("customer_email")
             plan = event_object.get("metadata", {}).get("plan")
             subscription_id = event_object.get("id")
-            
+
             # Find user by email
             users_ref = db.collection("users").where("email", "==", customer_email)
             users = list(users_ref.stream())
-            
+
             if users:
                 user_id = users[0].id
                 subscription_manager.update_subscription(user_id, plan, subscription_id)
                 logger.info(f"Updated subscription for user {user_id} to {plan}")
-            
+
         elif event_type == "subscription.cancelled":
             # Subscription cancelled
             subscription_id = event_object.get("id")
-            
+
             # Find user by subscription ID
-            users_ref = db.collection("users").where("subscription.dodo_subscription_id", "==", subscription_id)
+            users_ref = db.collection("users").where(
+                "subscription.dodo_subscription_id", "==", subscription_id
+            )
             users = list(users_ref.stream())
-            
+
             if users:
                 user_id = users[0].id
                 subscription_manager.cancel_subscription(user_id)
                 logger.info(f"Cancelled subscription for user {user_id}")
-        
+
         # Note: Invoice events not available in current Dodo setup
         # Invoice handling can be added later when available
-        
+
         return jsonify({"success": True})
-        
+
     except Exception as e:
         logger.error(f"Error processing webhook: {str(e)}")
         return jsonify({"error": "Webhook processing failed"}), 500
@@ -2033,9 +2262,6 @@ import time
 from chat_engine import get_chat_agent
 
 
-
-
-
 @app.route("/api/form/<form_id>/public")
 def get_form_public(form_id):
     """Get public form metadata (title, active status) for widget usage"""
@@ -2043,22 +2269,24 @@ def get_form_public(form_id):
         # Get form from Firestore
         form_ref = db.collection("forms").document(form_id)
         form_doc = form_ref.get()
-        
+
         if not form_doc.exists:
             return jsonify({"success": False, "error": "Form not found"}), 404
-        
+
         form_data = form_doc.to_dict()
-        
+
         # Return only public metadata needed for widget
-        return jsonify({
-            "success": True,
-            "form": {
-                "title": form_data.get("title", "Survey"),
-                "active": form_data.get("active", False),
-                "form_id": form_id
+        return jsonify(
+            {
+                "success": True,
+                "form": {
+                    "title": form_data.get("title", "Survey"),
+                    "active": form_data.get("active", False),
+                    "form_id": form_id,
+                },
             }
-        })
-        
+        )
+
     except Exception as e:
         logger.error(f"Error getting public form data: {str(e)}")
         return jsonify({"success": False, "error": "Failed to get form data"}), 500
@@ -2093,6 +2321,9 @@ def form_response_page(form_id):
                 403,
             )
 
+        if form_data.get("mode") == "voice":
+            return redirect(url_for("voice_form_page", form_id=form_id))
+
         return render_template(
             "chat.html",
             form_id=form_id,
@@ -2102,6 +2333,53 @@ def form_response_page(form_id):
 
     except Exception as e:
         print(f"Error loading form page: {str(e)}")
+        return (
+            render_template(
+                "error.html",
+                error_title="Error Loading Form",
+                error_message="There was an error loading this form. Please try again later.",
+            ),
+            500,
+        )
+
+
+@app.route("/voice/<form_id>")
+def voice_form_page(form_id):
+    """Voice interview page"""
+    try:
+        form_doc = db.collection("forms").document(form_id).get()
+        if not form_doc.exists:
+            return (
+                render_template(
+                    "error.html",
+                    error_title="Form Not Found",
+                    error_message="This form doesn't exist or has been removed.",
+                ),
+                404,
+            )
+
+        form_data = form_doc.to_dict()
+        if form_data.get("mode") != "voice":
+            return redirect(url_for("form_response_page", form_id=form_id))
+
+        if not form_data.get("active", False):
+            return (
+                render_template(
+                    "error.html",
+                    error_title="Survey Not Available",
+                    error_message="This survey is currently paused and not accepting responses.",
+                ),
+                403,
+            )
+
+        return render_template(
+            "voice.html",
+            form_id=form_id,
+            form_title=form_data.get("title", "Survey"),
+            agent_id=form_data.get("voice_settings", {}).get("agent_id", ""),
+        )
+    except Exception as e:
+        print(f"Error loading voice form page: {str(e)}")
         return (
             render_template(
                 "error.html",
@@ -2142,18 +2420,22 @@ def embed_form(form_id):
             )
 
         # Create response with CORS headers for embedding
-        response = app.make_response(render_template(
-            "embed.html",
-            form_id=form_id,
-            form_title=form_data.get("title", "Survey"),
-            form_description=form_data.get("description", ""),
-        ))
-        
+        response = app.make_response(
+            render_template(
+                "embed.html",
+                form_id=form_id,
+                form_title=form_data.get("title", "Survey"),
+                form_description=form_data.get("description", ""),
+            )
+        )
+
         # Add headers to allow iframe embedding from any domain
         # Remove X-Frame-Options to let CSP handle framing
-        response.headers.pop('X-Frame-Options', None)
-        response.headers['Content-Security-Policy'] = "frame-ancestors https: http: file:"
-        
+        response.headers.pop("X-Frame-Options", None)
+        response.headers["Content-Security-Policy"] = (
+            "frame-ancestors https: http: file:"
+        )
+
         return response
 
     except Exception as e:
@@ -2171,11 +2453,29 @@ def embed_form(form_id):
 @app.route("/widget.js")
 def widget_script():
     """Serve the widget JavaScript file with proper CORS headers"""
-    response = send_from_directory('static', 'widget.js', mimetype='application/javascript')
-    response.headers['Access-Control-Allow-Origin'] = '*'
-    response.headers['Access-Control-Allow-Methods'] = 'GET'
-    response.headers['Cache-Control'] = 'public, max-age=3600'  # Cache for 1 hour
+    response = send_from_directory(
+        "static", "widget.js", mimetype="application/javascript"
+    )
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = "GET"
+    response.headers["Cache-Control"] = "public, max-age=3600"  # Cache for 1 hour
     return response
+
+
+@app.route("/api/voice/token", methods=["POST"])
+def get_voice_token():
+    """Generate an ephemeral ElevenLabs token for voice sessions"""
+    data = request.get_json() or {}
+    agent_id = data.get("agent_id")
+    if not agent_id:
+        return jsonify({"success": False, "error": "agent_id required"}), 400
+
+    try:
+        token_info = create_ephemeral_token(agent_id)
+        return jsonify({"success": True, **token_info})
+    except Exception as e:
+        logger.error(f"Error generating voice token: {str(e)}")
+        return jsonify({"success": False, "error": "Failed to generate token"}), 500
 
 
 @app.route("/api/chat/start", methods=["POST"])
@@ -2225,7 +2525,9 @@ def start_chat_session():
 
                 # First, let's check all sessions for this device_id
                 all_device_sessions = list(
-                    sessions_ref.where(filter=FieldFilter("metadata.device_id", "==", device_id)).stream()
+                    sessions_ref.where(
+                        filter=FieldFilter("metadata.device_id", "==", device_id)
+                    ).stream()
                 )
                 print(
                     f"Total sessions for device {device_id}: {len(all_device_sessions)}"
@@ -2247,9 +2549,7 @@ def start_chat_session():
                 # First get all sessions for this device and form
                 query = sessions_ref.where(
                     filter=FieldFilter("metadata.device_id", "==", device_id)
-                ).where(
-                    filter=FieldFilter("form_id", "==", form_id)
-                )
+                ).where(filter=FieldFilter("form_id", "==", form_id))
 
                 # Get all matching sessions
                 all_matching = list(query.stream())
@@ -2309,12 +2609,15 @@ def start_chat_session():
                         session_id, "Hello, I'm back to continue our conversation!"
                     )
                     greeting_message = greeting_result.get(
-                        "response", "Great to have you back! Let's continue our conversation. 😊"
+                        "response",
+                        "Great to have you back! Let's continue our conversation. 😊",
                     )
                 except Exception as e:
                     print(f"Error getting resumption greeting: {e}")
-                    greeting_message = "Great to have you back! Let's continue our conversation. 😊"
-                
+                    greeting_message = (
+                        "Great to have you back! Let's continue our conversation. 😊"
+                    )
+
                 return jsonify(
                     {
                         "session_id": session_id,
@@ -2360,7 +2663,6 @@ def start_chat_session():
         return jsonify({"error": "Failed to start chat session"}), 500
 
 
-
 @app.route("/api/chat/message", methods=["POST"])
 def process_chat_message():
     """Process a chat message"""
@@ -2382,21 +2684,29 @@ def process_chat_message():
             agent = get_chat_agent()
             print(f"PRODUCTION DEBUG: Got agent: {type(agent)}", file=sys.stderr)
             result = agent.process_message(session_id, message)
-            print(f"PRODUCTION DEBUG: Result keys: {list(result.keys())}", file=sys.stderr)
+            print(
+                f"PRODUCTION DEBUG: Result keys: {list(result.keys())}", file=sys.stderr
+            )
             print(f"PRODUCTION DEBUG: Result content: {result}", file=sys.stderr)
         except Exception as agent_error:
             # Log the error for debugging
             import traceback
+
             print(f"CRITICAL: Chat agent failed: {str(agent_error)}", file=sys.stderr)
             print(f"TRACEBACK: {traceback.format_exc()}", file=sys.stderr)
-            
+
             # Return a generic fallback response
-            return jsonify({
-                "response": "I'm having trouble processing that right now. Could you try again?",
-                "success": True,
-                "error": f"agent_error: {str(agent_error)}",
-                "fallback": True
-            }), 200
+            return (
+                jsonify(
+                    {
+                        "response": "I'm having trouble processing that right now. Could you try again?",
+                        "success": True,
+                        "error": f"agent_error: {str(agent_error)}",
+                        "fallback": True,
+                    }
+                ),
+                200,
+            )
 
         if not result.get("success"):
             return (
@@ -2415,7 +2725,7 @@ def process_chat_message():
 
         # Check if conversation ended
         conversation_ended = result.get("metadata", {}).get("ended", False)
-        
+
         # Get chat length for partial extraction triggers
         chat_length = result.get("metadata", {}).get("chat_length", 0)
 
@@ -2430,16 +2740,19 @@ def process_chat_message():
 
         # Background extraction is now handled automatically by chat_engine.py
         # No need for synchronous extraction here
-        
+
         # Trigger partial extraction every 5 messages for long conversations
         if not conversation_ended and chat_length > 0 and chat_length % 5 == 0:
             try:
                 from background_extraction import queue_extraction
+
                 queue_extraction(session_id, f"partial_extraction_msg_{chat_length}")
-                print(f"Queued partial extraction for session {session_id} at message {chat_length}")
+                print(
+                    f"Queued partial extraction for session {session_id} at message {chat_length}"
+                )
             except Exception as e:
                 print(f"Warning: Could not queue partial extraction: {e}")
-                
+
         response_data["background_extraction"] = True
 
         return jsonify(response_data)
@@ -2447,20 +2760,22 @@ def process_chat_message():
     except Exception as e:
         # Enhanced error logging for debugging
         import traceback
+
         error_details = {
             "error_type": type(e).__name__,
             "error_message": str(e),
             "traceback": traceback.format_exc(),
-            "request_data": data if 'data' in locals() else None,
-            "message": data.get('message') if 'data' in locals() and data else None
+            "request_data": data if "data" in locals() else None,
+            "message": data.get("message") if "data" in locals() and data else None,
         }
         print(f"🚨 CHAT MESSAGE ERROR: {error_details}")
-        
+
         # Also log to file for debugging
-        with open('/tmp/flask_errors.log', 'a') as f:
+        with open("/tmp/flask_errors.log", "a") as f:
             from datetime import datetime
+
             f.write(f"{datetime.now()}: {error_details}\n")
-        
+
         return (
             jsonify(
                 {
@@ -2530,73 +2845,68 @@ def check_chips():
         data = request.get_json()
         session_id = data.get("session_id")
         message = data.get("message")
-        
+
         if not session_id or not message:
-            return jsonify({"success": False, "error": "Missing session_id or message"}), 400
-            
+            return (
+                jsonify({"success": False, "error": "Missing session_id or message"}),
+                400,
+            )
+
         # Get the chat session from the appropriate engine
         if USE_GROQ:
-            from groq_chat_engine import load_session, _get_natural_question_data
+            from groq_chat_engine import _get_natural_question_data, load_session
         else:
-            from chat_engine import load_session, _get_natural_question_data
-        
+            from chat_engine import _get_natural_question_data, load_session
+
         try:
             session = load_session(session_id)
         except Exception as e:
-            return jsonify({"success": False, "error": f"Session not found: {str(e)}"}), 404
-            
+            return (
+                jsonify({"success": False, "error": f"Session not found: {str(e)}"}),
+                404,
+            )
+
         # Get current question being asked
         questions = session.form_data.get("questions", [])
         current_q_idx = session.current_question_index
-        
+
         # Check if we have a valid current question
         if current_q_idx >= len(questions):
-            return jsonify({
-                "success": True,
-                "chip_options": {"show_chips": False}
-            })
-            
+            return jsonify({"success": True, "chip_options": {"show_chips": False}})
+
         current_q = questions[current_q_idx]
-        
+
         # Skip if this question is not enabled
         if not current_q.get("enabled", True):
-            return jsonify({
-                "success": True,
-                "chip_options": {"show_chips": False}
-            })
-            
+            return jsonify({"success": True, "chip_options": {"show_chips": False}})
+
         # Skip if already answered
         if str(current_q_idx) in session.responses:
-            return jsonify({
-                "success": True,
-                "chip_options": {"show_chips": False}
-            })
-        
+            return jsonify({"success": True, "chip_options": {"show_chips": False}})
+
         # Use the existing logic from chat_engine to determine chips
         natural_q_data = _get_natural_question_data(
-            session_id, 
-            current_q.get("text", ""), 
-            current_q.get("type", "text"), 
-            current_q_idx
+            session_id,
+            current_q.get("text", ""),
+            current_q.get("type", "text"),
+            current_q_idx,
         )
-        
+
         if natural_q_data.get("show_chips"):
             chip_options = {
                 "show_chips": True,
                 "question_type": natural_q_data.get("chip_type"),
-                "options": natural_q_data.get("chip_options", [])
+                "options": natural_q_data.get("chip_options", []),
             }
         else:
             chip_options = {"show_chips": False}
-        
-        return jsonify({
-            "success": True,
-            "chip_options": chip_options
-        })
-        
+
+        return jsonify({"success": True, "chip_options": chip_options})
+
     except Exception as e:
         print(f"Error checking chips: {str(e)}")
         import traceback
+
         print(f"Traceback: {traceback.format_exc()}")
         return jsonify({"success": False, "error": "Internal server error"}), 500
 
@@ -2652,7 +2962,9 @@ def get_form_responses(form_id):
 
         # Get responses
         responses_query = (
-            db.collection("responses").where(filter=FieldFilter("form_id", "==", form_id)).stream()
+            db.collection("responses")
+            .where(filter=FieldFilter("form_id", "==", form_id))
+            .stream()
         )
         responses = []
 
@@ -2672,6 +2984,7 @@ def get_form_responses(form_id):
                     "metadata": response_data.get("metadata", {}),
                     "created_at": created_at,
                     "partial": response_data.get("partial", False),
+                    "mode": response_data.get("mode", "chat"),
                 }
             )
 
@@ -2704,7 +3017,9 @@ def generate_wordcloud(form_id, question_index):
 
         # Get responses for this question
         responses_query = (
-            db.collection("responses").where(filter=FieldFilter("form_id", "==", form_id)).stream()
+            db.collection("responses")
+            .where(filter=FieldFilter("form_id", "==", form_id))
+            .stream()
         )
         text_responses = []
 
@@ -2882,7 +3197,9 @@ def export_responses(form_id, format):
 
         # Get responses
         responses_query = (
-            db.collection("responses").where(filter=FieldFilter("form_id", "==", form_id)).stream()
+            db.collection("responses")
+            .where(filter=FieldFilter("form_id", "==", form_id))
+            .stream()
         )
         responses = []
 
@@ -2981,29 +3298,30 @@ def update_form_status(form_id):
 
         # Update active status (convert string to boolean)
         is_active = new_status == "active"
-        
+
         # Check if this is first time going live (for email notification)
         was_previously_active = form_data.get("active", False)
-        first_time_active = is_active and not was_previously_active and not form_data.get("first_activated", False)
-        
-        update_data = {
-            "active": is_active, 
-            "updated_at": datetime.now().isoformat()
-        }
-        
+        first_time_active = (
+            is_active
+            and not was_previously_active
+            and not form_data.get("first_activated", False)
+        )
+
+        update_data = {"active": is_active, "updated_at": datetime.now().isoformat()}
+
         # Track first activation to avoid duplicate emails
         if first_time_active:
             update_data["first_activated"] = True
             update_data["first_activated_at"] = datetime.now().isoformat()
-        
+
         db.collection("forms").document(form_id).update(update_data)
-        
+
         # Send email notification for first time activation
         if first_time_active:
             try:
                 creator_id = form_data.get("creator_id")
                 form_title = form_data.get("title", "Untitled Form")
-                
+
                 # Get creator email and name
                 if creator_id:
                     creator_doc = db.collection("users").document(creator_id).get()
@@ -3011,15 +3329,19 @@ def update_form_status(form_id):
                         creator_data = creator_doc.to_dict()
                         creator_email = creator_data.get("email")
                         creator_name = creator_data.get("name")
-                        
+
                         if creator_email:
                             email_result = email_service.send_survey_live_email(
                                 creator_email, form_title, form_id, creator_name
                             )
                             if email_result.get("success"):
-                                logger.info(f"Survey live email sent to {creator_email} for form {form_id}")
+                                logger.info(
+                                    f"Survey live email sent to {creator_email} for form {form_id}"
+                                )
                             else:
-                                logger.warning(f"Failed to send survey live email: {email_result.get('error')}")
+                                logger.warning(
+                                    f"Failed to send survey live email: {email_result.get('error')}"
+                                )
             except Exception as e:
                 logger.error(f"Error sending survey live email: {str(e)}")
 
@@ -3050,14 +3372,18 @@ def delete_form(form_id):
         db.collection("forms").document(form_id).delete()
 
         # Delete associated responses (optional - you might want to keep them)
-        responses_ref = db.collection("responses").where(filter=FieldFilter("form_id", "==", form_id))
+        responses_ref = db.collection("responses").where(
+            filter=FieldFilter("form_id", "==", form_id)
+        )
         responses = responses_ref.stream()
 
         for response in responses:
             response.reference.delete()
 
         # Delete chat sessions
-        sessions_ref = db.collection("chat_sessions").where(filter=FieldFilter("form_id", "==", form_id))
+        sessions_ref = db.collection("chat_sessions").where(
+            filter=FieldFilter("form_id", "==", form_id)
+        )
         sessions = sessions_ref.stream()
 
         for session in sessions:
@@ -3070,68 +3396,83 @@ def delete_form(form_id):
         return jsonify({"error": "Failed to delete form"}), 500
 
 
-
 @app.route("/api/test/extraction/<session_id>")
 def test_extraction_endpoint(session_id):
     """Test endpoint to check extraction data for a session"""
     try:
         # Check chat_responses collection first
         response_doc = db.collection("chat_responses").document(session_id).get()
-        
+
         if response_doc.exists:
             response_data = response_doc.to_dict()
             form_data = response_data.get("form_data", {})
-            
-            return jsonify({
-                "session_id": session_id,
-                "form_title": form_data.get("title", "Unknown Form"),
-                "responses": response_data.get("responses", {}),
-                "chat_history": response_data.get("chat_history", []),
-                "metadata": response_data.get("metadata", {}),
-                "extraction_found": True
-            })
-        
+
+            return jsonify(
+                {
+                    "session_id": session_id,
+                    "form_title": form_data.get("title", "Unknown Form"),
+                    "responses": response_data.get("responses", {}),
+                    "chat_history": response_data.get("chat_history", []),
+                    "metadata": response_data.get("metadata", {}),
+                    "extraction_found": True,
+                }
+            )
+
         # If not in chat_responses, check chat_sessions
         session_doc = db.collection("chat_sessions").document(session_id).get()
-        
+
         if session_doc.exists:
             session_data = session_doc.to_dict()
             form_data = session_data.get("form_data", {})
-            
-            return jsonify({
-                "session_id": session_id,
-                "form_title": form_data.get("title", "Unknown Form"),
-                "responses": session_data.get("responses", {}),
-                "chat_history": session_data.get("chat_history", []),
-                "metadata": session_data.get("metadata", {}),
-                "extraction_found": True,
-                "note": "Found in chat_sessions (may not be ended yet)"
-            })
-        
-        return jsonify({
-            "error": "Session not found",
-            "session_id": session_id,
-            "extraction_found": False
-        }), 404
-        
+
+            return jsonify(
+                {
+                    "session_id": session_id,
+                    "form_title": form_data.get("title", "Unknown Form"),
+                    "responses": session_data.get("responses", {}),
+                    "chat_history": session_data.get("chat_history", []),
+                    "metadata": session_data.get("metadata", {}),
+                    "extraction_found": True,
+                    "note": "Found in chat_sessions (may not be ended yet)",
+                }
+            )
+
+        return (
+            jsonify(
+                {
+                    "error": "Session not found",
+                    "session_id": session_id,
+                    "extraction_found": False,
+                }
+            ),
+            404,
+        )
+
     except Exception as e:
-        return jsonify({
-            "error": f"Failed to retrieve extraction data: {str(e)}",
-            "session_id": session_id,
-            "extraction_found": False
-        }), 500
+        return (
+            jsonify(
+                {
+                    "error": f"Failed to retrieve extraction data: {str(e)}",
+                    "session_id": session_id,
+                    "extraction_found": False,
+                }
+            ),
+            500,
+        )
 
 
 # =================
 # ADMIN ROUTES
 # =================
 
+
 @app.route("/admin")
 def admin_login():
     """Admin login page"""
-    if session.get('admin_authenticated'):
-        return redirect(url_for('admin_dashboard'))
+    if session.get("admin_authenticated"):
+        return redirect(url_for("admin_dashboard"))
     return render_template("admin_login.html")
+
 
 @app.route("/admin/login", methods=["POST"])
 def admin_login_post():
@@ -3139,39 +3480,42 @@ def admin_login_post():
     try:
         data = request.get_json()
         password = data.get("password")
-        
+
         if not password:
             return jsonify({"success": False, "error": "Password required"}), 400
-        
+
         # Get client IP
-        client_ip = request.environ.get('HTTP_X_FORWARDED_FOR', request.remote_addr)
-        
+        client_ip = request.environ.get("HTTP_X_FORWARDED_FOR", request.remote_addr)
+
         # Verify admin password
         if admin.verify_admin_password(password):
-            session['admin_authenticated'] = True
-            session['admin_last_activity'] = datetime.now().timestamp()
+            session["admin_authenticated"] = True
+            session["admin_last_activity"] = datetime.now().timestamp()
             admin.log_admin_login(True, client_ip)
             return jsonify({"success": True})
         else:
             admin.log_admin_login(False, client_ip)
             return jsonify({"success": False, "error": "Invalid password"}), 401
-            
+
     except Exception as e:
         logger.error(f"Admin login error: {str(e)}")
         return jsonify({"success": False, "error": "Login failed"}), 500
 
+
 @app.route("/admin/logout", methods=["POST"])
 def admin_logout():
     """Handle admin logout"""
-    session.pop('admin_authenticated', None)
-    session.pop('admin_last_activity', None)
+    session.pop("admin_authenticated", None)
+    session.pop("admin_last_activity", None)
     return jsonify({"success": True})
+
 
 @app.route("/admin/dashboard")
 # @admin_required
 def admin_dashboard():
     """Admin dashboard page"""
     return render_template("admin_dashboard.html")
+
 
 @app.route("/admin/api/dashboard")
 # @admin_required
@@ -3188,6 +3532,7 @@ def admin_api_dashboard():
 
 # A/B test route removed completely
 
+
 @app.route("/admin/api/trends")
 # @admin_required
 def admin_api_trends():
@@ -3200,52 +3545,58 @@ def admin_api_trends():
         logger.error(f"Error fetching trends data: {str(e)}")
         return jsonify({"error": "Failed to fetch trends data"}), 500
 
+
 @app.route("/admin/api/debug/counts")
-# @admin_required  
+# @admin_required
 def admin_debug_counts():
     """Debug endpoint to check raw Firebase collection counts"""
     try:
         users_ref = db.collection("users")
         forms_ref = db.collection("forms")
         responses_ref = db.collection("responses")
-        
+
         users_count = len(list(users_ref.limit(1000).stream()))
         forms_count = len(list(forms_ref.limit(1000).stream()))
         responses_count = len(list(responses_ref.limit(1000).stream()))
-        
+
         # Get a sample user document to check structure
         sample_user = None
         sample_users = []
         users_sample = list(users_ref.limit(3).stream())
         for user_doc in users_sample:
             user_data = user_doc.to_dict()
-            sample_users.append({
-                "id": user_doc.id,
-                "email": user_data.get("email"),
-                "created_at": user_data.get("created_at"),
-                "created_at_type": str(type(user_data.get("created_at"))),
-                "has_created_at": "created_at" in user_data
-            })
+            sample_users.append(
+                {
+                    "id": user_doc.id,
+                    "email": user_data.get("email"),
+                    "created_at": user_data.get("created_at"),
+                    "created_at_type": str(type(user_data.get("created_at"))),
+                    "has_created_at": "created_at" in user_data,
+                }
+            )
         if users_sample:
             sample_user = users_sample[0].to_dict()
-            
-        return jsonify({
-            "raw_counts": {
-                "users": users_count,
-                "forms": forms_count,
-                "responses": responses_count
-            },
-            "sample_user": sample_user,
-            "sample_users": sample_users,
-            "collections_exist": {
-                "users": users_count > 0,
-                "forms": forms_count > 0,
-                "responses": responses_count > 0
+
+        return jsonify(
+            {
+                "raw_counts": {
+                    "users": users_count,
+                    "forms": forms_count,
+                    "responses": responses_count,
+                },
+                "sample_user": sample_user,
+                "sample_users": sample_users,
+                "collections_exist": {
+                    "users": users_count > 0,
+                    "forms": forms_count > 0,
+                    "responses": responses_count > 0,
+                },
             }
-        })
+        )
     except Exception as e:
         logger.error(f"Debug counts error: {str(e)}")
         return jsonify({"error": str(e)}), 500
+
 
 @app.route("/admin/api/users/search")
 # @admin_required
@@ -3255,12 +3606,13 @@ def admin_search_users():
         query = request.args.get("q", "").strip()
         if not query:
             return jsonify([])
-        
+
         users = admin_metrics.search_users(query)
         return jsonify(users)
     except Exception as e:
         logger.error(f"Error searching users: {str(e)}")
         return jsonify({"error": "Search failed"}), 500
+
 
 @app.route("/admin/api/users/<user_id>")
 # @admin_required
@@ -3268,10 +3620,14 @@ def admin_get_user_details(user_id):
     """Get detailed user information"""
     try:
         details = admin_metrics.get_user_details(user_id)
-        return jsonify(details) if details else jsonify({"error": "User not found"}), 404
+        return (
+            jsonify(details) if details else jsonify({"error": "User not found"}),
+            404,
+        )
     except Exception as e:
         logger.error(f"Error fetching user details: {str(e)}")
         return jsonify({"error": "Failed to fetch user details"}), 500
+
 
 @app.route("/admin/api/users/<user_id>/grandfather", methods=["POST"])
 # @admin_required
@@ -3280,12 +3636,13 @@ def admin_grant_grandfather(user_id):
     try:
         data = request.get_json()
         plan_type = data.get("plan_type", "pro")
-        
+
         success = admin_metrics.grant_grandfather_status(user_id, plan_type)
         return jsonify({"success": success})
     except Exception as e:
         logger.error(f"Error granting grandfather status: {str(e)}")
         return jsonify({"error": "Operation failed"}), 500
+
 
 @app.route("/admin/api/users/<user_id>/reset-usage", methods=["POST"])
 # @admin_required
@@ -3298,6 +3655,7 @@ def admin_reset_user_usage(user_id):
         logger.error(f"Error resetting user usage: {str(e)}")
         return jsonify({"error": "Operation failed"}), 500
 
+
 @app.route("/admin/api/users/recent")
 # @admin_required
 def admin_get_recent_users():
@@ -3308,6 +3666,7 @@ def admin_get_recent_users():
     except Exception as e:
         logger.error(f"Error fetching recent users: {str(e)}")
         return jsonify({"error": "Failed to fetch recent users"}), 500
+
 
 @app.route("/admin/api/users/<user_id>/forms")
 # @admin_required
@@ -3320,6 +3679,7 @@ def admin_get_user_forms(user_id):
         logger.error(f"Error fetching user forms: {str(e)}")
         return jsonify({"error": "Failed to fetch user forms"}), 500
 
+
 @app.route("/admin/api/users/<user_id>/export")
 # @admin_required
 def admin_export_user_data(user_id):
@@ -3328,17 +3688,17 @@ def admin_export_user_data(user_id):
         details = admin_metrics.get_user_details(user_id)
         if not details:
             return jsonify({"error": "User not found"}), 404
-        
+
         # Add export metadata
         export_data = {
             "export_info": {
                 "user_id": user_id,
                 "exported_at": datetime.now().isoformat(),
-                "exported_by": "admin"
+                "exported_by": "admin",
             },
-            "user_data": details
+            "user_data": details,
         }
-        
+
         return jsonify(export_data)
     except Exception as e:
         logger.error(f"Error exporting user data: {str(e)}")
@@ -3347,5 +3707,6 @@ def admin_export_user_data(user_id):
 
 if __name__ == "__main__":
     import os
-    port = int(os.environ.get('FLASK_RUN_PORT', 5555))
+
+    port = int(os.environ.get("FLASK_RUN_PORT", 5555))
     app.run(debug=True, port=port)

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -16,19 +16,24 @@ import openai
 # Debug import issue
 try:
     from agents import Agent, Runner, function_tool
+
     print("SUCCESS: OpenAI Agents SDK imported", file=os.sys.stderr)
 except ImportError as e:
     print(f"CRITICAL ERROR: Cannot import OpenAI Agents SDK: {e}", file=os.sys.stderr)
+
     # Create dummy classes to prevent complete failure
     class Agent:
         def __init__(self, *args, **kwargs):
             raise ImportError("OpenAI Agents SDK not available")
+
     class Runner:
         @staticmethod
         def run_sync(*args, **kwargs):
             raise ImportError("OpenAI Agents SDK not available")
+
     def function_tool(func):
         return func
+
 
 from dotenv import load_dotenv
 from firebase_admin import db, firestore
@@ -117,21 +122,25 @@ def load_session(session_id: str) -> ChatSession:
 
     # Load from Firestore
     try:
-        session_doc = firestore_db.collection("chat_sessions").document(session_id).get()
+        session_doc = (
+            firestore_db.collection("chat_sessions").document(session_id).get()
+        )
 
         if session_doc.exists:
             session_data = session_doc.to_dict()
-            
+
             # Validate required fields
             required_fields = ["session_id", "form_id", "form_data"]
             for field in required_fields:
                 if not session_data.get(field):
                     raise ValueError(f"Session missing required field: {field}")
-            
+
             # Ensure form_data has questions
-            if not isinstance(session_data.get("form_data"), dict) or not session_data["form_data"].get("questions"):
+            if not isinstance(session_data.get("form_data"), dict) or not session_data[
+                "form_data"
+            ].get("questions"):
                 raise ValueError("Session has invalid form_data structure")
-            
+
             session = ChatSession(
                 session_id=session_data["session_id"],
                 form_id=session_data["form_id"],
@@ -145,7 +154,7 @@ def load_session(session_id: str) -> ChatSession:
             return session
         else:
             raise ValueError(f"Session {session_id} not found")
-            
+
     except Exception as e:
         # Clean up any corrupted session from memory
         if session_id in active_sessions:
@@ -200,11 +209,11 @@ def get_conversation_state(session_id: str) -> dict:
     try:
         session = load_session(session_id)
         questions = session.form_data.get("questions", [])
-        
+
         # Find current unanswered question - USE PERSISTENT INDEX
         current_question_index = session.metadata.get("current_question_index", 0)
         current_question = None
-        
+
         # Ensure we stay on the correct question until properly answered
         for i in range(current_question_index, len(questions)):
             q = questions[i]
@@ -220,51 +229,59 @@ def get_conversation_state(session_id: str) -> dict:
                 session.metadata["current_question_index"] = i
                 save_session(session)
                 break
-        
+
         # Calculate progress
         enabled_questions = [q for q in questions if q.get("enabled", True)]
-        answered_count = len([r for r in session.responses.values() if r.get("value") != "[SKIP]"])
-        
+        answered_count = len(
+            [r for r in session.responses.values() if r.get("value") != "[SKIP]"]
+        )
+
         return {
             "current_question": current_question,
             "progress": {
                 "answered": answered_count,
                 "total": len(enabled_questions),
-                "skipped": session.metadata.get("skip_count", 0)
+                "skipped": session.metadata.get("skip_count", 0),
             },
             "conversation_state": {
                 "message_count": len(session.chat_history),
                 "redirect_count": session.metadata.get("redirect_count", 0),
                 "session_ended": session.metadata.get("ended", False),
-                "time_elapsed": _calculate_time_elapsed(session.metadata.get("start_time")),
-                "pending_end_confirmation": session.metadata.get("pending_end_confirmation", False)
+                "time_elapsed": _calculate_time_elapsed(
+                    session.metadata.get("start_time")
+                ),
+                "pending_end_confirmation": session.metadata.get(
+                    "pending_end_confirmation", False
+                ),
             },
-            "recent_responses": _get_recent_responses(session, limit=3)
+            "recent_responses": _get_recent_responses(session, limit=3),
         }
     except Exception as e:
         return {"error": str(e)}
 
 
 @function_tool
-def save_user_response(session_id: str, response_text: str, question_index: int) -> dict:
+def save_user_response(
+    session_id: str, response_text: str, question_index: int
+) -> dict:
     """Save user response for a specific question"""
     try:
         session = load_session(session_id)
-        
+
         # Save response (NO RAW TEXT - for extraction later)
         session.responses[str(question_index)] = {
             "value": response_text,
             "timestamp": datetime.now().isoformat(),
             "question_index": question_index,
-            "question_type": session.form_data["questions"][question_index]["type"]
+            "question_type": session.form_data["questions"][question_index]["type"],
         }
-        
+
         save_session(session)
-        
+
         return {
             "saved": True,
             "response_id": f"{session_id}_q{question_index}",
-            "responses_count": len(session.responses)
+            "responses_count": len(session.responses),
         }
     except Exception as e:
         return {"saved": False, "error": str(e)}
@@ -276,10 +293,10 @@ def advance_to_next_question(session_id: str) -> dict:
     try:
         session = load_session(session_id)
         questions = session.form_data.get("questions", [])
-        
+
         # Get current index from metadata
         current_index = session.metadata.get("current_question_index", 0)
-        
+
         # Find next enabled, unanswered question
         next_question = None
         for i in range(current_index + 1, len(questions)):
@@ -295,59 +312,60 @@ def advance_to_next_question(session_id: str) -> dict:
                 # Update metadata to track new current question
                 session.metadata["current_question_index"] = i
                 break
-        
+
         save_session(session)
-        
+
         # Check if all questions completed
         enabled_questions = [q for q in questions if q.get("enabled", True)]
-        answered_count = len([r for r in session.responses.values() if r.get("value") != "[SKIP]"])
+        answered_count = len(
+            [r for r in session.responses.values() if r.get("value") != "[SKIP]"]
+        )
         all_completed = answered_count >= len(enabled_questions)
-        
+
         # Check for additional data collection (demographics & profile)
         demographics_enabled = []
         profile_data_enabled = []
-        
+
         if all_completed:
             # Get enabled demographics
             demographics = session.form_data.get("demographics", {})
             demographics_enabled = [k for k, v in demographics.items() if v]
-            
+
             # Get enabled profile data
             profile_data = session.form_data.get("profile_data", {})
             profile_data_enabled = [k for k, v in profile_data.items() if v]
-        
+
         return {
             "advanced": True,
             "next_question": next_question,
             "all_questions_completed": all_completed,
             "demographics_enabled": demographics_enabled,
             "profile_data_enabled": profile_data_enabled,
-            "progress": {
-                "answered": answered_count,
-                "total": len(enabled_questions)
-            }
+            "progress": {"answered": answered_count, "total": len(enabled_questions)},
         }
     except Exception as e:
         return {"advanced": False, "error": str(e)}
 
 
 @function_tool
-def update_session_state(session_id: str, action: str, reason: str = "user_request") -> dict:
+def update_session_state(
+    session_id: str, action: str, reason: str = "user_request"
+) -> dict:
     """Update session state for skip, end, redirect tracking, etc."""
     try:
         session = load_session(session_id)
-        
+
         if action == "skip":
             session.metadata["skip_count"] += 1
             current_idx = session.current_question_index
             session.responses[str(current_idx)] = {
                 "value": "[SKIP]",
                 "timestamp": datetime.now().isoformat(),
-                "reason": reason
+                "reason": reason,
             }
             # Move to next question
             session.current_question_index += 1
-            
+
         elif action == "end":
             # SAFETY CHECK: Only allow ending if confirmation was already requested
             if not session.metadata.get("pending_end_confirmation", False):
@@ -355,27 +373,36 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
                     "action_completed": False,
                     "error": "Cannot end without confirmation. Use 'request_end_confirmation' first.",
                     "session_ended": False,
-                    "requires_confirmation": True
+                    "requires_confirmation": True,
                 }
-            
+
             # Proceed with ending
             session.metadata["ended"] = True
             session.metadata["end_time"] = datetime.now().isoformat()
             session.metadata["end_reason"] = reason
             session.metadata["pending_end_confirmation"] = False  # Clear pending state
             # Calculate if partial
-            enabled_count = len([q for q in session.form_data.get("questions", []) if q.get("enabled", True)])
-            answered_count = len([r for r in session.responses.values() if r.get("value") != "[SKIP]"])
+            enabled_count = len(
+                [
+                    q
+                    for q in session.form_data.get("questions", [])
+                    if q.get("enabled", True)
+                ]
+            )
+            answered_count = len(
+                [r for r in session.responses.values() if r.get("value") != "[SKIP]"]
+            )
             session.metadata["partial"] = answered_count < enabled_count * 0.8
-            
+
             # Handle extraction based on environment
             # Vercel cannot run background threads, so we do synchronous extraction
             if os.environ.get("VERCEL"):
                 # Synchronous extraction for Vercel/serverless
                 try:
                     from data_extraction import DataExtractionChain
+
                     extractor = DataExtractionChain()
-                    
+
                     # Load session for extraction
                     session_data = {
                         "session_id": session_id,
@@ -383,13 +410,15 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
                         "form_data": session.form_data,
                         "responses": session.responses,
                         "chat_history": session.chat_history,
-                        "metadata": session.metadata
+                        "metadata": session.metadata,
                     }
-                    
+
                     # Extract and save responses synchronously
                     result = extractor.save_extracted_responses(session_data)
                     if result.get("success"):
-                        print(f"Synchronous extraction completed for session {session_id}")
+                        print(
+                            f"Synchronous extraction completed for session {session_id}"
+                        )
                     else:
                         print(f"Synchronous extraction failed: {result.get('error')}")
                 except Exception as e:
@@ -398,30 +427,34 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
                 # Background extraction for local development
                 try:
                     from background_extraction import queue_extraction
+
                     queue_extraction(session_id, f"chat_ended_{reason}")
-                    print(f"Queued background extraction for ended session {session_id}")
+                    print(
+                        f"Queued background extraction for ended session {session_id}"
+                    )
                 except Exception as e:
                     print(f"Warning: Could not queue background extraction: {e}")
-            
+
         elif action == "request_end_confirmation":
             # User wants to end but needs confirmation
             session.metadata["pending_end_confirmation"] = True
             session.metadata["end_request_time"] = datetime.now().isoformat()
-            
+
         elif action == "redirect":
             session.metadata["redirect_count"] += 1
-            
+
         elif action == "timeout":
             session.metadata["partial"] = True
             session.metadata["timeout"] = True
-            
+
             # Handle extraction based on environment (same as above)
             if os.environ.get("VERCEL"):
                 # Synchronous extraction for Vercel/serverless
                 try:
                     from data_extraction import DataExtractionChain
+
                     extractor = DataExtractionChain()
-                    
+
                     # Load session for extraction
                     session_data = {
                         "session_id": session_id,
@@ -429,13 +462,15 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
                         "form_data": session.form_data,
                         "responses": session.responses,
                         "chat_history": session.chat_history,
-                        "metadata": session.metadata
+                        "metadata": session.metadata,
                     }
-                    
+
                     # Extract and save responses synchronously
                     result = extractor.save_extracted_responses(session_data)
                     if result.get("success"):
-                        print(f"Synchronous extraction completed for timeout session {session_id}")
+                        print(
+                            f"Synchronous extraction completed for timeout session {session_id}"
+                        )
                     else:
                         print(f"Synchronous extraction failed: {result.get('error')}")
                 except Exception as e:
@@ -444,19 +479,24 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
                 # Background extraction for local development
                 try:
                     from background_extraction import queue_extraction
+
                     queue_extraction(session_id, "timeout")
-                    print(f"Queued background extraction for timeout session {session_id}")
+                    print(
+                        f"Queued background extraction for timeout session {session_id}"
+                    )
                 except Exception as e:
                     print(f"Warning: Could not queue background extraction: {e}")
-            
+
         save_session(session)
-        
+
         return {
             "action_completed": True,
             "action": action,
             "session_ended": session.metadata.get("ended", False),
             "redirect_count": session.metadata.get("redirect_count", 0),
-            "pending_end_confirmation": session.metadata.get("pending_end_confirmation", False)
+            "pending_end_confirmation": session.metadata.get(
+                "pending_end_confirmation", False
+            ),
         }
     except Exception as e:
         return {"action_completed": False, "error": str(e)}
@@ -465,6 +505,7 @@ def update_session_state(session_id: str, action: str, reason: str = "user_reque
 # ============================================================
 # HELPER FUNCTIONS
 # ============================================================
+
 
 def _calculate_time_elapsed(start_time_str: str) -> int:
     """Calculate seconds elapsed since start time"""
@@ -482,11 +523,13 @@ def _get_recent_responses(session: ChatSession, limit: int = 3) -> List[Dict]:
     recent = []
     for idx, response in sorted(session.responses.items(), key=lambda x: x[0])[-limit:]:
         if response.get("value") != "[SKIP]":
-            recent.append({
-                "question_index": idx,
-                "value": response["value"],
-                "timestamp": response.get("timestamp")
-            })
+            recent.append(
+                {
+                    "question_index": idx,
+                    "value": response["value"],
+                    "timestamp": response.get("timestamp"),
+                }
+            )
     return recent
 
 
@@ -494,159 +537,220 @@ def _get_recent_responses(session: ChatSession, limit: int = 3) -> List[Dict]:
 # NEW INTELLIGENT TOOLS FOR PROMPT REFACTORING
 # ============================================================
 
+
 @function_tool
-def validate_response(session_id: str, response: str, question_type: str, validation_type: str = None) -> dict:
+def validate_response(
+    session_id: str, response: str, question_type: str, validation_type: str = None
+) -> dict:
     """Enhanced validation with human-like conversation guidance
-    
+
     Args:
         session_id: Current session ID
         response: User's response text
         question_type: text/multiple_choice/yes_no/rating/number
         validation_type: Optional - email/phone/linkedin/website/nonsense/vague
-    
+
     Returns validation result with contextual, natural follow-up suggestions
     """
     import re
-    
+
     try:
         session = get_session(session_id)
         if not session:
             return {"valid": False, "error": "Session not found"}
-        
+
         # Get conversation context for personalized responses
         chat_history = session.chat_history[-3:] if session.chat_history else []
         user_name = None
         previous_responses = []
-        
+
         # Extract user name and previous context from chat history
         for message in session.chat_history:
             if message.get("role") == "user":
                 content = message.get("content", "").strip()
                 # Simple name detection from early responses
-                if len(content.split()) <= 3 and any(char.isalpha() for char in content):
+                if len(content.split()) <= 3 and any(
+                    char.isalpha() for char in content
+                ):
                     if not user_name and len(content) < 30:
                         potential_name = content.split()[0]
-                        if potential_name.lower() not in ['yes', 'no', 'maybe', 'sure', 'ok', 'okay']:
+                        if potential_name.lower() not in [
+                            "yes",
+                            "no",
+                            "maybe",
+                            "sure",
+                            "ok",
+                            "okay",
+                        ]:
                             user_name = potential_name
                 previous_responses.append(content)
-        
+
         # Normalize response for analysis
         response_clean = response.strip()
         response_lower = response.strip().lower()
-        
+
         # Enhanced nonsense detection with context awareness
         nonsense_patterns = [
-            r'^[0-9]+$',  # Just numbers for non-number questions
-            r'^(ola|bhoot|ringa|la+|ha+|lol|lmao|rofl|omg|wtf|idk).*',  # Common nonsense
-            r'^[^a-zA-Z0-9\s]{3,}$',  # Special chars only
-            r'^(.)\1{4,}',  # Repeated chars (aaaaa, !!!!!!)
-            r'^(asdf|qwerty|zxcv|test|hello world).*',  # Keyboard mashing
+            r"^[0-9]+$",  # Just numbers for non-number questions
+            r"^(ola|bhoot|ringa|la+|ha+|lol|lmao|rofl|omg|wtf|idk).*",  # Common nonsense
+            r"^[^a-zA-Z0-9\s]{3,}$",  # Special chars only
+            r"^(.)\1{4,}",  # Repeated chars (aaaaa, !!!!!!)
+            r"^(asdf|qwerty|zxcv|test|hello world).*",  # Keyboard mashing
         ]
-        
+
         # Creative nonsense indicators with context
         creative_nonsense_indicators = [
-            'bananas', 'purple elephants', 'flying unicorns', 'rainbow dragons', 'aliens',
-            'moon cheese', 'chocolate rain', 'dancing penguins', 'singing cats', 'magic wizard',
-            'pokemon battle', 'superhero cape', 'batman signal', 'superman flying', 'fairy dust'
+            "bananas",
+            "purple elephants",
+            "flying unicorns",
+            "rainbow dragons",
+            "aliens",
+            "moon cheese",
+            "chocolate rain",
+            "dancing penguins",
+            "singing cats",
+            "magic wizard",
+            "pokemon battle",
+            "superhero cape",
+            "batman signal",
+            "superman flying",
+            "fairy dust",
         ]
-        
+
         # Check if response contains multiple unrelated concepts (likely nonsense)
         response_words = response.lower().split()
-        nonsense_word_count = sum(1 for word in response_words if word in creative_nonsense_indicators)
-        
+        nonsense_word_count = sum(
+            1 for word in response_words if word in creative_nonsense_indicators
+        )
+
         # If response has 2+ nonsense indicators for serious questions, it's likely nonsense
-        if (nonsense_word_count >= 2 and question_type in ['multiple_choice', 'rating', 'yes_no'] and 
-            len(response_words) <= 6):  # Short responses with multiple nonsense words
+        if (
+            nonsense_word_count >= 2
+            and question_type in ["multiple_choice", "rating", "yes_no"]
+            and len(response_words) <= 6
+        ):  # Short responses with multiple nonsense words
             return {
                 "valid": False,
                 "reason": "creative_nonsense",
                 "suggestion": "I need a real answer here. Can you give me a serious response?",
-                "confidence": 0.9
+                "confidence": 0.9,
             }
-        
-        if question_type not in ['number', 'rating'] and validation_type != 'email':
+
+        if question_type not in ["number", "rating"] and validation_type != "email":
             for pattern in nonsense_patterns:
                 if re.match(pattern, response):
                     return {
                         "valid": False,
                         "reason": "nonsense",
                         "suggestion": "I need a real answer here. Can you give me an actual response?",
-                        "confidence": 0.9
+                        "confidence": 0.9,
                     }
-        
+
         # Check for vague responses
-        vague_responses = ['meh', 'idk', 'dunno', 'whatever', 'nothing', 'none', 'idc', 'maybe', 'perhaps']
+        vague_responses = [
+            "meh",
+            "idk",
+            "dunno",
+            "whatever",
+            "nothing",
+            "none",
+            "idc",
+            "maybe",
+            "perhaps",
+        ]
         if response in vague_responses:
             return {
                 "valid": False,
                 "reason": "vague",
                 "suggestion": "Can you be more specific? Even a rough idea would help!",
-                "confidence": 0.8
+                "confidence": 0.8,
             }
-        
+
         # Validation by type
-        if validation_type == 'email':
-            email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        if validation_type == "email":
+            email_pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
             if re.match(email_pattern, response):
                 return {"valid": True, "cleaned_value": response, "confidence": 1.0}
             return {
                 "valid": False,
                 "reason": "invalid_email",
                 "suggestion": "Could you share that as an email address? (like user@domain.com)",
-                "confidence": 0.9
+                "confidence": 0.9,
             }
-            
-        elif validation_type == 'phone':
+
+        elif validation_type == "phone":
             # Remove common separators
-            cleaned = re.sub(r'[\s\-\(\)\+\.]', '', response)
-            if re.match(r'^[0-9]{10,15}$', cleaned):
+            cleaned = re.sub(r"[\s\-\(\)\+\.]", "", response)
+            if re.match(r"^[0-9]{10,15}$", cleaned):
                 return {"valid": True, "cleaned_value": cleaned, "confidence": 1.0}
             return {
                 "valid": False,
                 "reason": "invalid_phone",
                 "suggestion": "What's your phone number? (10-15 digits)",
-                "confidence": 0.9
+                "confidence": 0.9,
             }
-            
-        elif validation_type == 'linkedin':
-            if 'linkedin.com/in/' in response or re.match(r'^[a-zA-Z0-9\-]+$', response):
+
+        elif validation_type == "linkedin":
+            if "linkedin.com/in/" in response or re.match(
+                r"^[a-zA-Z0-9\-]+$", response
+            ):
                 return {"valid": True, "cleaned_value": response, "confidence": 1.0}
             return {
                 "valid": False,
                 "reason": "invalid_linkedin",
                 "suggestion": "What's your LinkedIn profile URL or username?",
-                "confidence": 0.8
+                "confidence": 0.8,
             }
-            
-        elif validation_type == 'website':
-            url_pattern = r'^(https?://)?([a-zA-Z0-9\-]+\.)+[a-zA-Z]{2,}.*$'
+
+        elif validation_type == "website":
+            url_pattern = r"^(https?://)?([a-zA-Z0-9\-]+\.)+[a-zA-Z]{2,}.*$"
             if re.match(url_pattern, response):
                 return {"valid": True, "cleaned_value": response, "confidence": 1.0}
             return {
                 "valid": False,
                 "reason": "invalid_website",
                 "suggestion": "What's your website URL?",
-                "confidence": 0.8
+                "confidence": 0.8,
             }
-            
-        elif question_type == 'rating':
-            if response in ['1', '2', '3', '4', '5']:
+
+        elif question_type == "rating":
+            if response in ["1", "2", "3", "4", "5"]:
                 return {"valid": True, "cleaned_value": response, "confidence": 1.0}
             # Try to extract number from text
-            numbers = re.findall(r'\b[1-5]\b', response)
+            numbers = re.findall(r"\b[1-5]\b", response)
             if numbers:
                 return {"valid": True, "cleaned_value": numbers[0], "confidence": 0.8}
             return {
                 "valid": False,
                 "reason": "invalid_rating",
                 "suggestion": "How would you rate that from 1 to 5?",
-                "confidence": 0.9
+                "confidence": 0.9,
             }
-            
-        elif question_type == 'yes_no':
-            yes_patterns = ['yes', 'yeah', 'yep', 'sure', 'definitely', 'absolutely', 'correct', 'right', 'true', 'y']
-            no_patterns = ['no', 'nope', 'nah', 'negative', 'false', 'wrong', 'incorrect', 'n']
-            
+
+        elif question_type == "yes_no":
+            yes_patterns = [
+                "yes",
+                "yeah",
+                "yep",
+                "sure",
+                "definitely",
+                "absolutely",
+                "correct",
+                "right",
+                "true",
+                "y",
+            ]
+            no_patterns = [
+                "no",
+                "nope",
+                "nah",
+                "negative",
+                "false",
+                "wrong",
+                "incorrect",
+                "n",
+            ]
+
             if any(pattern in response for pattern in yes_patterns):
                 return {"valid": True, "cleaned_value": "yes", "confidence": 0.9}
             elif any(pattern in response for pattern in no_patterns):
@@ -655,64 +759,80 @@ def validate_response(session_id: str, response: str, question_type: str, valida
                 "valid": False,
                 "reason": "unclear_yes_no",
                 "suggestion": "Is that a yes or no?",
-                "confidence": 0.7
+                "confidence": 0.7,
             }
-            
-        elif question_type == 'number':
-            numbers = re.findall(r'\b\d+\b', response)
+
+        elif question_type == "number":
+            numbers = re.findall(r"\b\d+\b", response)
             if numbers:
                 return {"valid": True, "cleaned_value": numbers[0], "confidence": 0.9}
             return {
                 "valid": False,
                 "reason": "no_number",
                 "suggestion": "Can you give me a number?",
-                "confidence": 0.8
+                "confidence": 0.8,
             }
-        
+
         # ENHANCED: Default validation with human-like suggestions for text questions
-        if question_type == 'text':
+        if question_type == "text":
             # Check for extremely short responses that might need elaboration
-            if len(response_clean) <= 2 and response_clean.lower() not in ['me', 'hi', 'ok', 'no', 'na', 'nm']:
+            if len(response_clean) <= 2 and response_clean.lower() not in [
+                "me",
+                "hi",
+                "ok",
+                "no",
+                "na",
+                "nm",
+            ]:
                 name_part = f" {user_name}" if user_name else ""
                 return {
                     "valid": False,
                     "reason": "too_short",
                     "suggestion": f"Can you tell me a bit more about that{name_part}? 😊",
-                    "confidence": 0.6
+                    "confidence": 0.6,
                 }
-            
+
             # Check for responses that seem dismissive but could be expanded
-            dismissive_patterns = ['fine', 'okay', 'ok', 'good', 'bad', 'nice', 'cool', 'meh']
+            dismissive_patterns = [
+                "fine",
+                "okay",
+                "ok",
+                "good",
+                "bad",
+                "nice",
+                "cool",
+                "meh",
+            ]
             if response_lower in dismissive_patterns and len(previous_responses) > 2:
                 return {
                     "valid": False,
-                    "reason": "needs_elaboration", 
+                    "reason": "needs_elaboration",
                     "suggestion": f"That's helpful! What specifically made it {response_lower} for you?",
-                    "confidence": 0.7
+                    "confidence": 0.7,
                 }
-        
+
         # Multiple choice questions - accept anything but suggest if unclear
-        elif question_type == 'multiple_choice':
+        elif question_type == "multiple_choice":
             # If response seems like they're trying to answer but unclear
-            if len(response_clean) > 1 and 'option' not in response_lower:
+            if len(response_clean) > 1 and "option" not in response_lower:
                 return {
                     "valid": True,
                     "cleaned_value": response_clean,
                     "confidence": 0.8,
-                    "note": "free_response_to_multiple_choice"
+                    "note": "free_response_to_multiple_choice",
                 }
-        
+
         # Default for other text questions - almost always valid unless nonsense
         return {
-            "valid": True, 
-            "cleaned_value": response_clean, 
+            "valid": True,
+            "cleaned_value": response_clean,
             "confidence": 0.85,
             "context": {
                 "user_name": user_name,
-                "response_count": len(previous_responses)
-            }
+                "response_count": len(previous_responses),
+            },
         }
-        
+
     except Exception as e:
         return {"valid": True, "error": str(e), "confidence": 0.5}
 
@@ -720,30 +840,62 @@ def validate_response(session_id: str, response: str, question_type: str, valida
 @function_tool
 def check_content_sensitivity(text: str) -> dict:
     """Detect concerning or emotional content and suggest appropriate responses
-    
+
     Args:
         text: User's message to analyze
-    
+
     Returns sensitivity analysis with suggested acknowledgment
     """
     try:
         text_lower = text.lower()
-        
+
         # Concerning content patterns
         concerning_keywords = [
-            'suicide', 'kill myself', 'end my life', 'death', 'dying', 'dead',
-            'bomb', 'bombing', 'explosion', 'violence', 'murder', 'killing',
-            'gun', 'weapon', 'shoot', 'attack', 'terrorism', 'harm', 'hurt',
-            'self-harm', 'cutting', 'bleeding', 'overdose'
+            "suicide",
+            "kill myself",
+            "end my life",
+            "death",
+            "dying",
+            "dead",
+            "bomb",
+            "bombing",
+            "explosion",
+            "violence",
+            "murder",
+            "killing",
+            "gun",
+            "weapon",
+            "shoot",
+            "attack",
+            "terrorism",
+            "harm",
+            "hurt",
+            "self-harm",
+            "cutting",
+            "bleeding",
+            "overdose",
         ]
-        
+
         # Emotional content patterns
         emotional_keywords = [
-            'angry', 'frustrated', 'sad', 'depressed', 'anxious', 'scared',
-            'hate', 'upset', 'crying', 'miserable', 'lonely', 'hopeless',
-            'stressed', 'overwhelmed', 'disappointed', 'heartbroken'
+            "angry",
+            "frustrated",
+            "sad",
+            "depressed",
+            "anxious",
+            "scared",
+            "hate",
+            "upset",
+            "crying",
+            "miserable",
+            "lonely",
+            "hopeless",
+            "stressed",
+            "overwhelmed",
+            "disappointed",
+            "heartbroken",
         ]
-        
+
         # Check for concerning content
         for keyword in concerning_keywords:
             if keyword in text_lower:
@@ -752,10 +904,16 @@ def check_content_sensitivity(text: str) -> dict:
                     "category": "serious_content",
                     "suggested_response": "That's really heavy. I hear you.",
                     "requires_acknowledgment": True,
-                    "never_say": ["No worries!", "Cool!", "Thanks for sharing!", "Got it!", "Interesting!"],
-                    "confidence": 0.95
+                    "never_say": [
+                        "No worries!",
+                        "Cool!",
+                        "Thanks for sharing!",
+                        "Got it!",
+                        "Interesting!",
+                    ],
+                    "confidence": 0.95,
                 }
-        
+
         # Check for emotional content
         for keyword in emotional_keywords:
             if keyword in text_lower:
@@ -765,24 +923,24 @@ def check_content_sensitivity(text: str) -> dict:
                     "suggested_response": "That sounds really tough.",
                     "requires_acknowledgment": True,
                     "never_say": ["Got it!", "Cool!", "No worries!"],
-                    "confidence": 0.85
+                    "confidence": 0.85,
                 }
-        
+
         # Normal content
         return {
             "severity": "normal",
             "category": "standard",
             "suggested_response": None,
             "requires_acknowledgment": False,
-            "confidence": 0.9
+            "confidence": 0.9,
         }
-        
+
     except Exception as e:
         return {
             "severity": "normal",
             "category": "error",
             "error": str(e),
-            "confidence": 0.5
+            "confidence": 0.5,
         }
 
 
@@ -791,48 +949,53 @@ def get_cached_natural_question(session_id: str, question_index: int) -> dict:
     try:
         session = load_session(session_id)
         questions = session.form_data.get("questions", [])
-        
+
         if question_index >= len(questions):
             return {"error": "Question index out of range"}
-        
+
         current_q = questions[question_index]
         cache_key = f"natural_q_{question_index}"
-        
+
         # Check if we have cached natural question
         if cache_key in session.metadata:
             return session.metadata[cache_key]
-        
+
         # Generate and cache natural question
         natural_data = _get_natural_question_data(
-            session_id, 
-            current_q.get("text", ""), 
+            session_id,
+            current_q.get("text", ""),
             current_q.get("type", "text"),
-            question_index
+            question_index,
         )
-        
+
         # Cache for consistency
         session.metadata[cache_key] = natural_data
         save_session(session)
-        
+
         return natural_data
-        
+
     except Exception as e:
         return {"error": str(e)}
 
-def _get_natural_question_data(session_id: str, question_text: str, question_type: str, question_index: int) -> dict:
+
+def _get_natural_question_data(
+    session_id: str, question_text: str, question_type: str, question_index: int
+) -> dict:
     """Helper function to get natural question data (used both by tool and chip extraction)"""
     try:
         session = load_session(session_id)
         questions = session.form_data.get("questions", [])
         current_q = questions[question_index] if question_index < len(questions) else {}
-        
+
         # Common conversational starters
         starters = ["Hey!", "So,", "Alright,", "Cool,", "Nice,", "Great,"]
-        starter = starters[question_index % len(starters)] if question_index > 0 else "Hey!"
-        
+        starter = (
+            starters[question_index % len(starters)] if question_index > 0 else "Hey!"
+        )
+
         # Transform based on type
         text_lower = question_text.lower()
-        
+
         # Natural transformations
         transformations = {
             # Demographics
@@ -842,7 +1005,6 @@ def _get_natural_question_data(session_id: str, question_text: str, question_typ
             "gender": "What's your gender?",
             "location": "Where are you from?",
             "occupation": "What do you do for work?",
-            
             # Common patterns
             "how satisfied": "How satisfied are you with this?",
             "rate your": "How would you rate this?",
@@ -854,29 +1016,33 @@ def _get_natural_question_data(session_id: str, question_text: str, question_typ
             "how often": f"{starter} How often do you",
             "how many": f"{starter} How many",
         }
-        
+
         # Find matching transformation
         natural_question = None
         for pattern, replacement in transformations.items():
             if pattern in text_lower:
                 natural_question = text_lower.replace(pattern, replacement)
                 break
-        
+
         if not natural_question:
             # Default transformations by type
             if question_type == "yes_no":
-                natural_question = f"{starter} {question_text}" if not question_text.startswith(("Do", "Are", "Is", "Can", "Would")) else question_text
+                natural_question = (
+                    f"{starter} {question_text}"
+                    if not question_text.startswith(("Do", "Are", "Is", "Can", "Would"))
+                    else question_text
+                )
             elif question_type == "rating":
                 natural_question = f"How would you rate {question_text.lower().replace('rate', '').strip()}?"
             elif question_type == "multiple_choice":
                 natural_question = f"{starter} {question_text.rstrip('?')}?"
             else:
                 natural_question = f"{starter} {question_text}"
-        
+
         # Prepare UI options for chips
         ui_options = []
         show_chips = False
-        
+
         if question_type == "yes_no":
             ui_options = ["Yes", "No"]
             show_chips = True
@@ -886,16 +1052,16 @@ def _get_natural_question_data(session_id: str, question_text: str, question_typ
         elif question_type == "multiple_choice" and current_q.get("options"):
             ui_options = current_q["options"][:5]  # Limit to 5 for UI
             show_chips = True
-        
+
         # Add follow-up prompts
         follow_ups = [
             "Tell me more about that",
             "Why's that?",
             "Can you elaborate?",
             "What makes you say that?",
-            "Interesting, why?"
+            "Interesting, why?",
         ]
-        
+
         return {
             "natural_question": natural_question.capitalize(),
             "show_chips": show_chips,
@@ -903,16 +1069,16 @@ def _get_natural_question_data(session_id: str, question_text: str, question_typ
             "chip_type": question_type if show_chips else None,
             "follow_up_prompts": follow_ups[:2],
             "question_index": question_index,
-            "original_text": question_text
+            "original_text": question_text,
         }
-        
+
     except Exception as e:
         # Fallback to original question
         return {
             "natural_question": question_text,
             "show_chips": False,
             "chip_options": [],
-            "error": str(e)
+            "error": str(e),
         }
 
 
@@ -922,30 +1088,36 @@ def get_current_question_naturally(session_id: str) -> dict:
     try:
         session = load_session(session_id)
         current_index = session.metadata.get("current_question_index", 0)
-        
+
         return get_cached_natural_question(session_id, current_index)
-        
+
     except Exception as e:
         return {"error": str(e)}
 
+
 @function_tool
-def get_natural_question(session_id: str, question_text: str, question_type: str, question_index: int) -> dict:
+def get_natural_question(
+    session_id: str, question_text: str, question_type: str, question_index: int
+) -> dict:
     """Transform formal questions into natural conversation with optional UI hints
-    
+
     Args:
         session_id: Current session ID
         question_text: Original question text
         question_type: text/multiple_choice/yes_no/rating/number
         question_index: Current question number
-    
+
     Returns natural phrasing and UI options for chips
     """
-    return _get_natural_question_data(session_id, question_text, question_type, question_index)
+    return _get_natural_question_data(
+        session_id, question_text, question_type, question_index
+    )
 
 
 # ============================================================
 # MAIN CHAT AGENT CLASS
 # ============================================================
+
 
 class FormChatAgent:
     """Simplified chat agent using OpenAI Agents SDK"""
@@ -958,13 +1130,14 @@ class FormChatAgent:
         # Set the API key in the environment for OpenAI Agents SDK
         os.environ["OPENAI_API_KEY"] = self.openai_api_key
         openai.api_key = self.openai_api_key
-        
+
         # Disable OpenAI telemetry to avoid traces/ingest errors
         os.environ["OPENAI_DISABLE_TELEMETRY"] = "true"
         os.environ["OPENAI_LOG_LEVEL"] = "error"  # Reduce logging noise
-        
+
         # Try to disable httpx INFO logging which shows the traces calls
         import logging
+
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
         # Ensure event loop exists for async operations
@@ -989,7 +1162,7 @@ class FormChatAgent:
                 update_session_state,
                 validate_response,
                 check_content_sensitivity,
-                get_natural_question
+                get_natural_question,
             ],
         )
 
@@ -1091,10 +1264,10 @@ You MUST call tools before every action. No exceptions. Create conversations tha
         """Get system instructions for the agent"""
         # Toggle between old (175 lines) and new (40 lines) prompt versions
         USE_SIMPLIFIED_PROMPT = True  # Set to True to activate new system
-        
+
         if USE_SIMPLIFIED_PROMPT:
             return self._get_system_instructions_v2()
-        
+
         # Original prompt (keeping for safety/rollback)
         return """# YOUR OBJECTIVE
 🎯 Your goal is to collect HIGH-QUALITY, MEANINGFUL responses for all survey questions. Quality matters more than speed. Don't accept nonsense or off-topic answers - probe for real insights.
@@ -1107,7 +1280,7 @@ You are Barney. Be casual, friendly, and direct. Keep responses under 20 words. 
 
 ## CONCERNING CONTENT (death, suicide, self-harm, violence, bombs, bombing, killing, hate, murder, gun, weapon):
 - MANDATORY: ALWAYS acknowledge seriousness FIRST: "That's really heavy" / "That sounds really difficult" / "That's concerning"
-- ABSOLUTELY NEVER say "No worries", "Cool", "Thanks for sharing", "Got it!" or "Interesting" 
+- ABSOLUTELY NEVER say "No worries", "Cool", "Thanks for sharing", "Got it!" or "Interesting"
 - NEVER use happy emojis (😊) or dismissive language with concerning content
 - Show genuine concern without being preachy
 - After acknowledging seriousness, gently continue: "I hear you. [next question]"
@@ -1119,14 +1292,14 @@ You are Barney. Be casual, friendly, and direct. Keep responses under 20 words. 
 
 ## ABSOLUTELY FORBIDDEN RESPONSES TO CONCERNING CONTENT:
 ❌ NEVER EVER: "No worries!" to bombs/violence/death/harm
-❌ NEVER EVER: "Thanks for sharing" to death/violence/harm  
+❌ NEVER EVER: "Thanks for sharing" to death/violence/harm
 ❌ NEVER EVER: "Cool" or "Awesome" to negative/concerning content
 ❌ NEVER EVER: Happy emojis (😊 🙂 😄) with concerning content
 ❌ NEVER EVER: "Interesting" to concerning statements
 ❌ NEVER EVER: "Got it!" to concerning/emotional content
 ❌ NEVER EVER: Dismissive phrases like "Let's move on" without acknowledgment first
 
-✅ APPROPRIATE: 
+✅ APPROPRIATE:
 - For concerning: "That's really heavy. [gentle transition to next]"
 - For emotional: "I hear that's frustrating. [next question]"
 - For normal: "Makes sense!" / "I see!"
@@ -1136,7 +1309,7 @@ You are Barney. Be casual, friendly, and direct. Keep responses under 20 words. 
 ❌ "Rate 1-5" / "Choose A/B" / "Here's the next question"
 ✅ "How satisfied are you?" / Natural transitions only
 
-FORBIDDEN: 
+FORBIDDEN:
 - "next question", "here it is", "question #X"
 - Over-explaining what you're doing
 - "I see we're kicking off with...", "I'm interested in understanding..."
@@ -1155,14 +1328,14 @@ REQUIRED: Context-appropriate acknowledgments based on content sensitivity
 
 # QUESTION TRANSFORMATION BY TYPE
 - text: "Tell me about..." / "What's..."
-- multiple_choice: Ask openly, ignore options  
+- multiple_choice: Ask openly, ignore options
 - yes_no: "Do you..." / "Are you..."
 - rating: "How satisfied..."
-- number: "How many..." 
+- number: "How many..."
 
 GOOD EXAMPLES:
 "Hey! How old are you?"
-"Nice. What's your gender?"  
+"Nice. What's your gender?"
 "Cool. How often do you shop?"
 
 BAD EXAMPLES (DON'T DO THIS):
@@ -1203,7 +1376,7 @@ Be DIRECT. No meta-commentary. No over-explaining. Just ask what you need to kno
 **Concerning/Sensitive Content**: Follow SAFETY RULES above - acknowledge seriousness first
 
 ## Probing Techniques
-- Echo: "Confusing how?"  
+- Echo: "Confusing how?"
 - Tell-me-more: "Can you paint me a picture?"
 - Example: "Can you think of a specific time?"
 - Why ladder: "What led to that?" / "What's important about that?"
@@ -1251,11 +1424,11 @@ ALWAYS respond to their actual message first. Never generic "welcome back".
 - Use inclusive language
 - Allow thoughtful pauses
 
-# CONTEXT-RELATED QUESTIONS 
+# CONTEXT-RELATED QUESTIONS
 🎯 **IMPORTANT**: If user asks about the bot, organization, survey purpose, or anything related to the Bot Context:
 1. Answer naturally using the Bot Context information (if provided)
 2. Keep response brief and helpful (under 20 words)
-3. **DO NOT** save_user_response() or advance_to_next_question() 
+3. **DO NOT** save_user_response() or advance_to_next_question()
 4. Smoothly redirect back to current survey question
 5. Example: "I'm Sarah from marketing! We're studying customer satisfaction. So about your shopping habits..."
 
@@ -1271,7 +1444,6 @@ Good: ✅ Stories, emotional language, elaboration
 Probe: ⚠️ All positive/negative, very short, rushing
 
 Be human, not a data collector."""
-
 
     def create_session(
         self, form_id: str, device_id: str = None, location: Dict = None
@@ -1301,6 +1473,7 @@ Be human, not a data collector."""
                     "redirect_count": 0,
                     "partial": False,
                     "ended": False,
+                    "mode": form_data.get("mode", "chat"),
                 },
             )
 
@@ -1309,6 +1482,7 @@ Be human, not a data collector."""
 
         except Exception as e:
             import traceback
+
             print(f"SESSION CREATION ERROR: {str(e)}")
             print(f"TRACEBACK: {traceback.format_exc()}")
             raise Exception(f"Failed to create session: {str(e)}")
@@ -1317,15 +1491,15 @@ Be human, not a data collector."""
         """Process a user message and return agent response"""
         try:
             session = load_session(session_id)
-            
+
             # Enhanced session validation
             if session.metadata.get("ended", False):
                 return {
                     "success": False,
                     "response": "This conversation has already ended. Thanks for your participation!",
-                    "error": "session_ended"
+                    "error": "session_ended",
                 }
-            
+
             # Check for session timeout (24 hours max)
             start_time_str = session.metadata.get("start_time")
             if start_time_str:
@@ -1340,26 +1514,26 @@ Be human, not a data collector."""
                         return {
                             "success": False,
                             "response": "This conversation has expired. Please start a new survey.",
-                            "error": "session_expired"
+                            "error": "session_expired",
                         }
                 except ValueError:
                     pass  # Continue if timestamp parsing fails
-            
+
             # Check if form is still active
             form_doc = firestore_db.collection("forms").document(session.form_id).get()
             if not form_doc.exists:
                 return {
                     "success": False,
                     "response": "Sorry, this survey is no longer available.",
-                    "error": "form_not_found"
+                    "error": "form_not_found",
                 }
-            
+
             form_data = form_doc.to_dict()
             if not form_data.get("active", False):
                 return {
                     "success": False,
                     "response": "Sorry, this survey is currently unavailable.",
-                    "error": "form_inactive"
+                    "error": "form_inactive",
                 }
 
             # Check for conversation break (more than 2 minutes since last message)
@@ -1387,27 +1561,43 @@ Be human, not a data collector."""
             )
 
             # Agent will use tools to understand current state - no hints needed
-            
+
             # Generate recap if needed
             recap_context = ""
             if recap_needed:
-                answered_count = len([r for r in session.responses.values() if r.get("value") != "[SKIP]"])
-                total_questions = len([q for q in session.form_data.get("questions", []) if q.get("enabled", True)])
+                answered_count = len(
+                    [
+                        r
+                        for r in session.responses.values()
+                        if r.get("value") != "[SKIP]"
+                    ]
+                )
+                total_questions = len(
+                    [
+                        q
+                        for q in session.form_data.get("questions", [])
+                        if q.get("enabled", True)
+                    ]
+                )
                 recap_context = f"\n[NOTE: Session resumed - {answered_count}/{total_questions} questions completed so far. Respond to their message naturally.]\n"
-            
+
             # Get recent conversation history for context
-            recent_history = session.chat_history[-6:] if len(session.chat_history) > 6 else session.chat_history
+            recent_history = (
+                session.chat_history[-6:]
+                if len(session.chat_history) > 6
+                else session.chat_history
+            )
             history_context = ""
             if recent_history:
                 history_context = "\nRecent conversation:\n"
                 for msg in recent_history:
                     role_label = "User" if msg["role"] == "user" else "You"
                     history_context += f"{role_label}: {msg['content']}\n"
-            
+
             # Prepare input for the agent with minimal context (NO RAW QUESTION TEXT)
-            bot_context = session.form_data.get('bot_context', '').strip()
+            bot_context = session.form_data.get("bot_context", "").strip()
             context_section = f"\nBot Context: {bot_context}\n" if bot_context else ""
-            
+
             agent_input = f"""
 Current session: {session_id}
 Form: {session.form_data.get('title', 'Survey')}{context_section}
@@ -1456,30 +1646,29 @@ Use your tools to understand the situation and respond naturally."""
                 current_q_idx = updated_session.current_question_index
                 questions = updated_session.form_data.get("questions", [])
                 ended = updated_session.metadata.get("ended", False)
-                
-                print(f"DEBUG: current_q_idx={current_q_idx}, questions_count={len(questions)}, ended={ended}")
-                
+
+                print(
+                    f"DEBUG: current_q_idx={current_q_idx}, questions_count={len(questions)}, ended={ended}"
+                )
+
                 # If we're asking a question (not ended), get chip options
                 if current_q_idx < len(questions) and not ended:
                     current_q = questions[current_q_idx]
                     q_type = current_q.get("type", "text")
                     q_text = current_q.get("text", "")
-                    
+
                     print(f"DEBUG: current question - type={q_type}, text={q_text}")
-                    
+
                     natural_q_result = _get_natural_question_data(
-                        session_id, 
-                        q_text, 
-                        q_type, 
-                        current_q_idx
+                        session_id, q_text, q_type, current_q_idx
                     )
                     print(f"DEBUG: get_natural_question result: {natural_q_result}")
-                    
+
                     if natural_q_result.get("show_chips"):
                         chip_options = {
                             "show_chips": True,
                             "chip_type": natural_q_result.get("chip_type"),
-                            "options": natural_q_result.get("chip_options", [])
+                            "options": natural_q_result.get("chip_options", []),
                         }
                         print(f"DEBUG: Setting chip_options: {chip_options}")
                     else:
@@ -1489,6 +1678,7 @@ Use your tools to understand the situation and respond naturally."""
             except Exception as e:
                 print(f"DEBUG: Error extracting chip options: {e}")
                 import traceback
+
                 print(f"DEBUG: Traceback: {traceback.format_exc()}")
 
             return {
@@ -1526,38 +1716,53 @@ def get_chat_agent():
     """Get or create the global chat agent instance"""
     global chat_agent
     if chat_agent is None:
-        import sys
         import datetime
+        import sys
+
         openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
         print(f"=== CHAT ENGINE VERSION CHECK ===", file=sys.stderr)
         print(f"TIMESTAMP: {datetime.datetime.now().isoformat()}", file=sys.stderr)
-        print(f"CHAT ENGINE: Using NEW system with industry safety rules (v2.0)", file=sys.stderr)
+        print(
+            f"CHAT ENGINE: Using NEW system with industry safety rules (v2.0)",
+            file=sys.stderr,
+        )
         print(f"DEBUG: API key available: {bool(openai_api_key)}", file=sys.stderr)
-        print(f"DEBUG: API key length: {len(openai_api_key) if openai_api_key else 0}", file=sys.stderr)
+        print(
+            f"DEBUG: API key length: {len(openai_api_key) if openai_api_key else 0}",
+            file=sys.stderr,
+        )
         print(f"DEBUG: Python version: {sys.version}", file=sys.stderr)
-        
+
         # Check if agents module is available
         try:
             import agents
-            print(f"DEBUG: agents module available: {agents.__version__ if hasattr(agents, '__version__') else 'unknown version'}", file=sys.stderr)
+
+            print(
+                f"DEBUG: agents module available: {agents.__version__ if hasattr(agents, '__version__') else 'unknown version'}",
+                file=sys.stderr,
+            )
         except ImportError as e:
             print(f"CRITICAL: agents module not available: {e}", file=sys.stderr)
             raise ImportError(f"OpenAI Agents SDK not installed: {e}")
-        
+
         if openai_api_key:
             print(f"DEBUG: API key prefix: {openai_api_key[:10]}...", file=sys.stderr)
-            print(f"DEBUG: API key ends with newline: {repr(openai_api_key[-2:])}", file=sys.stderr)
+            print(
+                f"DEBUG: API key ends with newline: {repr(openai_api_key[-2:])}",
+                file=sys.stderr,
+            )
 
         if not openai_api_key:
             print("ERROR: OPENAI_API_KEY environment variable not set", file=sys.stderr)
             raise ValueError("OPENAI_API_KEY environment variable not set")
-        
+
         try:
             chat_agent = FormChatAgent(openai_api_key)
             print("DEBUG: Chat agent created successfully", file=sys.stderr)
         except Exception as e:
             print(f"CRITICAL: Failed to create FormChatAgent: {e}", file=sys.stderr)
             import traceback
+
             print(f"TRACEBACK: {traceback.format_exc()}", file=sys.stderr)
             raise
     return chat_agent

--- a/static/js/voice.js
+++ b/static/js/voice.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const startBtn = document.getElementById('start-btn');
+  if (!startBtn) return;
+
+  startBtn.addEventListener('click', async () => {
+    try {
+      const res = await fetch('/api/voice/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: window.AGENT_ID })
+      });
+      const data = await res.json();
+      console.log('Received token', data);
+    } catch (err) {
+      console.error('Failed to get token', err);
+    }
+  });
+});

--- a/templates/responses.html
+++ b/templates/responses.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#cc5500">
     <title>{{ form_title }} - Responses | Barmuda Forms</title>
-    
+
     <!-- Google Analytics (GA4) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7C7SPTNMLT"></script>
     <script>
@@ -18,19 +18,19 @@
             allow_ad_personalization_signals: false
         });
     </script>
-    
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
-    
+
     <!-- Chart.js and WordCloud Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/wordcloud@1.2.3/src/wordcloud2.js"></script>
-    
+
     <!-- Phosphor Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
-    
+
     <!-- Custom Chart Configurations -->
     <script src="/static/js/chart-config.js"></script>
     <script src="/static/js/wordcloud-config.js"></script>
@@ -139,7 +139,7 @@
                 </div>
             </div>
         </div>
-        
+
         <!-- Insights View -->
         <div id="insights-content" class="hidden">
             <div class="bg-white rounded-lg border border-[#fce9c1] p-4 md:p-6">
@@ -155,7 +155,7 @@
                 </div>
             </div>
         </div>
-        
+
         <!-- Questions View -->
         <div id="questions-content" class="hidden">
             <div class="bg-white rounded-lg border border-[#fce9c1] p-4 md:p-6">
@@ -188,7 +188,7 @@
             try {
                 const response = await fetch(`/api/responses/${formId}`);
                 const data = await response.json();
-                
+
                 if (response.ok) {
                     allResponses = data.responses;
                     updateStats(data);
@@ -209,7 +209,7 @@
             const totalResponses = data.total_responses;
             const completeResponses = data.responses.filter(r => !r.partial).length;
             const completionRate = totalResponses > 0 ? Math.round((completeResponses / totalResponses) * 100) : 0;
-            
+
             // Calculate total messages and average time
             let totalMessages = 0;
             let totalTime = 0;
@@ -217,7 +217,7 @@
 
             data.responses.forEach(response => {
                 totalMessages += response.metadata.chat_length || 0;
-                
+
                 const startTime = response.metadata.start_time;
                 const endTime = response.metadata.end_time;
                 if (startTime && endTime) {
@@ -240,14 +240,14 @@
         function renderSummary(data) {
             const container = document.getElementById('questions-summary');
             const questions = {{ questions | tojsonfilter }};
-            
+
             questions.forEach((question, index) => {
                 const questionCard = document.createElement('div');
                 questionCard.className = 'bg-white rounded-xl border border-[#fce9c1] p-4 md:p-6 lg:p-8 shadow-sm hover:shadow-md transition-shadow overflow-visible';
-                
+
                 const responses = data.responses.map(r => r.responses[index.toString()]).filter(r => r !== undefined && r !== null);
                 const responseCount = responses.length;
-                
+
                 let summaryHtml = `
                     <div class="mb-4 md:mb-6">
                         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
@@ -284,7 +284,7 @@
 
                 questionCard.innerHTML = summaryHtml;
                 container.appendChild(questionCard);
-                
+
                 // Initialize visualization after DOM is updated
                 setTimeout(() => {
                     if (question.type === 'text') {
@@ -301,7 +301,7 @@
             try {
                 const response = await fetch(`/api/wordcloud/${formId}/${questionIndex}`);
                 const data = await response.json();
-                
+
                 if (data.success && data.word_frequency.length > 0) {
                     renderBackendWordCloud(`wordcloud-${questionIndex}`, data.word_frequency);
                 } else {
@@ -332,31 +332,31 @@
             // Render word cloud using backend-generated data
             const container = document.getElementById(containerId);
             if (!container) return;
-            
+
             // Clear container and set proper sizing
             container.innerHTML = '';
             container.style.width = '100%';
             container.style.height = '200px';
             container.style.overflow = 'visible';
             container.style.position = 'relative';
-            
+
             // Create HTML-based word cloud with better sizing
             const colors = ['#e17d36', '#cc5500', '#d12b2e', '#ff6b35', '#e4b65b'];
             const maxCount = Math.max(...wordFrequency.map(item => item.count));
-            
+
             // Limit to top 15 words for better display
             const topWords = wordFrequency.slice(0, 15);
-            
+
             let wordsHtml = '';
             topWords.forEach((item, index) => {
                 const size = Math.max(14, Math.min(28, (item.count / maxCount) * 20 + 14));
                 const color = colors[index % colors.length];
                 const fontWeight = item.count > maxCount * 0.7 ? '700' : item.count > maxCount * 0.4 ? '600' : '500';
-                
+
                 wordsHtml += `
                     <span style="
-                        font-size: ${size}px; 
-                        color: ${color}; 
+                        font-size: ${size}px;
+                        color: ${color};
                         margin: 2px 4px;
                         font-family: 'DM Sans';
                         font-weight: ${fontWeight};
@@ -366,7 +366,7 @@
                     ">${item.word}</span>
                 `;
             });
-            
+
             container.innerHTML = `
                 <div style="
                     display: flex;
@@ -390,20 +390,21 @@
         function renderIndividual(data) {
             const container = document.getElementById('individual-responses');
             const questions = {{ questions | tojsonfilter }};
-            
+
             data.responses.forEach((response, index) => {
                 const responseCard = document.createElement('div');
                 responseCard.className = 'border border-[#fce9c1] rounded-lg p-3 md:p-4 mb-4';
-                
+
                 let html = `
                     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-3 gap-2">
                         <h4 class="font-['DM_Sans'] font-medium text-[#1e1e1e] text-sm md:text-[16px]">Response #${index + 1}</h4>
                         <div class="flex gap-2">
+                            <span class="bg-[#fdeada] text-[#cc5500] px-2 py-1 rounded text-xs">${response.mode || 'chat'}</span>
                             ${response.partial ? '<span class="bg-yellow-100 text-yellow-800 px-2 py-1 rounded text-xs">Partial</span>' : ''}
                             <span class="text-[#797878] text-xs">${response.created_at ? new Date(response.created_at).toLocaleDateString() : 'Unknown date'}</span>
                         </div>
                     </div>
-                    
+
                     <!-- Structured Responses -->
                     <div class="space-y-3 mb-4">
                         <h5 class="font-['DM_Sans'] font-semibold text-[#1e1e1e] text-sm mb-2">Extracted Responses</h5>
@@ -412,7 +413,7 @@
                 questions.forEach((question, qIndex) => {
                     const answer = response.responses[qIndex.toString()];
                     const value = answer ? answer.value : 'No response';
-                    
+
                     html += `
                         <div class="flex flex-col">
                             <span class="font-['DM_Sans'] font-medium text-[#1e1e1e] text-xs md:text-[14px] mb-1">Q${qIndex + 1}: ${question.text}</span>
@@ -422,7 +423,7 @@
                 });
 
                 html += '</div>';
-                
+
                 // Add Chat Transcript if available
                 if (response.chat_transcript && response.chat_transcript.length > 0) {
                     html += `
@@ -437,12 +438,12 @@
                             <div id="chat-transcript-${index}" class="hidden bg-[#fef9ee] rounded-lg p-3 max-h-64 overflow-y-auto">
                                 <div class="space-y-2">
                     `;
-                    
+
                     response.chat_transcript.forEach((message, msgIndex) => {
                         if (message.role === 'user' || message.role === 'assistant') {
                             const isUser = message.role === 'user';
                             const time = message.timestamp ? new Date(message.timestamp).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) : '';
-                            
+
                             html += `
                                 <div class="flex ${isUser ? 'justify-end' : 'justify-start'}">
                                     <div class="max-w-xs ${isUser ? 'bg-[#cc5500] text-white' : 'bg-white border border-[#e5e7eb]'} rounded-lg px-3 py-2">
@@ -453,7 +454,7 @@
                             `;
                         }
                     });
-                    
+
                     html += `
                                 </div>
                             </div>
@@ -469,18 +470,18 @@
                         </div>
                     `;
                 }
-                
+
                 responseCard.innerHTML = html;
                 container.appendChild(responseCard);
             });
         }
-        
+
         // Function to toggle chat transcript visibility
         function toggleChatTranscript(index) {
             const transcript = document.getElementById(`chat-transcript-${index}`);
             const toggleText = document.getElementById(`toggle-text-${index}`);
             const toggleIcon = document.getElementById(`toggle-icon-${index}`);
-            
+
             if (transcript.classList.contains('hidden')) {
                 transcript.classList.remove('hidden');
                 toggleText.textContent = 'Hide';
@@ -497,11 +498,11 @@
             const tabs = ['summary', 'individual', 'insights', 'questions'];
             const activeClasses = 'flex-1 bg-gradient-to-r from-[#cc5500] to-[#d12b2e] text-white rounded-lg px-2 md:px-4 py-2 md:py-3 flex items-center justify-center gap-1 md:gap-2 transition-all';
             const inactiveClasses = 'flex-1 bg-transparent text-[#cc5500] rounded-lg px-2 md:px-4 py-2 md:py-3 flex items-center justify-center gap-1 md:gap-2 transition-all hover:bg-[#fff5e0]';
-            
+
             tabs.forEach(tab => {
                 const tabElement = document.getElementById(`${tab}-tab`);
                 const contentElement = document.getElementById(`${tab}-content`);
-                
+
                 if (tab === activeTabId) {
                     tabElement.className = activeClasses;
                     contentElement.classList.remove('hidden');
@@ -511,7 +512,7 @@
                 }
             });
         }
-        
+
         // Tab event listeners
         document.getElementById('summary-tab').addEventListener('click', () => switchTab('summary', 'summary-content'));
         document.getElementById('individual-tab').addEventListener('click', () => switchTab('individual', 'individual-content'));
@@ -525,7 +526,7 @@
         async function exportData(format) {
             try {
                 const response = await fetch(`/api/export/${formId}/${format}`);
-                
+
                 if (response.ok) {
                     const blob = await response.blob();
                     const url = window.URL.createObjectURL(blob);
@@ -544,13 +545,13 @@
                 alert('Failed to export data. Please try again.');
             }
         }
-        
+
         // Get question preview based on type
         function getQuestionPreview(question, responses) {
             if (!responses || responses.length === 0) {
                 return '<div class="text-xs text-[#959494] font-[\'DM_Sans\']">No responses yet</div>';
             }
-            
+
             switch(question.type) {
                 case 'multiple_choice':
                     // Show top choice
@@ -566,7 +567,7 @@
                         <div class="text-xs text-[#1e1e1e] font-['DM_Sans'] truncate">${topChoice}</div>
                         <div class="text-xs text-[#797878] font-['DM_Sans']">${topPercent}%</div>
                     `;
-                    
+
                 case 'yes_no':
                     const yesCount = responses.filter(r => r.value === 'Yes').length;
                     const yesPercent = Math.round((yesCount / responses.length) * 100);
@@ -575,7 +576,7 @@
                         <div class="text-2xl text-[#1e1e1e] font-['DM_Sans'] font-bold">${yesPercent}%</div>
                         <div class="text-xs text-[#797878] font-['DM_Sans']">${yesCount}/${responses.length}</div>
                     `;
-                    
+
                 case 'rating':
                     const ratings = responses.map(r => parseInt(r.value)).filter(r => !isNaN(r));
                     const avgRating = ratings.length > 0 ? (ratings.reduce((a, b) => a + b, 0) / ratings.length).toFixed(1) : 0;
@@ -587,7 +588,7 @@
                         </div>
                         <div class="text-xs text-[#797878] font-['DM_Sans']">${ratings.length} ratings</div>
                     `;
-                    
+
                 case 'number':
                     const numbers = responses.map(r => parseFloat(r.value)).filter(r => !isNaN(r));
                     const avgNumber = numbers.length > 0 ? (numbers.reduce((a, b) => a + b, 0) / numbers.length).toFixed(1) : 0;
@@ -596,7 +597,7 @@
                         <div class="text-lg text-[#1e1e1e] font-['DM_Sans'] font-bold">${avgNumber}</div>
                         <div class="text-xs text-[#797878] font-['DM_Sans']">${numbers.length} numbers</div>
                     `;
-                    
+
                 case 'text':
                     const textResponses = responses.filter(r => r.value && r.value !== '[SKIP]');
                     const avgLength = textResponses.length > 0 ? Math.round(textResponses.reduce((sum, r) => sum + (r.value?.length || 0), 0) / textResponses.length) : 0;
@@ -605,7 +606,7 @@
                         <div class="text-lg text-[#1e1e1e] font-['DM_Sans'] font-bold">${textResponses.length}</div>
                         <div class="text-xs text-[#797878] font-['DM_Sans']">${avgLength} avg chars</div>
                     `;
-                    
+
                 default:
                     return `
                         <div class="text-xs text-[#cc5500] font-['DM_Sans'] font-bold mb-1">Responses</div>
@@ -613,21 +614,21 @@
                     `;
             }
         }
-        
+
         // View question details function
         function viewQuestionDetails(questionIndex) {
             // Switch to summary tab and scroll to the specific question
             switchTab('summary', 'summary-content');
-            
+
             // Wait for tab switch animation, then scroll to question
             setTimeout(() => {
                 const questionCards = document.querySelectorAll('#questions-summary > div');
                 if (questionCards[questionIndex]) {
-                    questionCards[questionIndex].scrollIntoView({ 
-                        behavior: 'smooth', 
-                        block: 'center' 
+                    questionCards[questionIndex].scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'center'
                     });
-                    
+
                     // Add temporary highlight effect
                     questionCards[questionIndex].style.boxShadow = '0 0 0 3px rgba(204, 85, 0, 0.3)';
                     setTimeout(() => {
@@ -641,15 +642,15 @@
         function renderQuestionsOverview() {
             const container = document.getElementById('questions-overview');
             const questions = {{ questions | tojsonfilter }};
-            
+
             // Clear and re-render
             container.innerHTML = '';
-            
+
             if (!questions || questions.length === 0) {
                 container.innerHTML = '<div class="text-center py-8 text-[#797878] bg-white rounded-lg border border-[#fce9c1] p-4">No questions found in this form</div>';
                 return;
             }
-            
+
             // Add summary header
             const summaryDiv = document.createElement('div');
             summaryDiv.className = 'bg-white rounded-lg border border-[#fce9c1] p-4 mb-6';
@@ -667,19 +668,19 @@
                 </div>
             `;
             container.appendChild(summaryDiv);
-            
+
             // Create enhanced question cards
             questions.forEach((question, index) => {
                 const questionCard = document.createElement('div');
                 questionCard.className = 'bg-white rounded-xl border border-[#fce9c1] p-6 shadow-sm hover:shadow-md transition-shadow mb-4';
-                
+
                 // Handle case where allResponses might not be loaded yet
                 const responses = allResponses ? allResponses.map(r => r.responses[index.toString()]).filter(r => r !== undefined && r !== null) : [];
                 const totalPossibleResponses = allResponses ? allResponses.length : 0;
                 const responseCount = responses.length;
                 const skipCount = totalPossibleResponses - responseCount;
                 const completionRate = totalPossibleResponses > 0 ? Math.round((responseCount / totalPossibleResponses) * 100) : 0;
-                
+
                 // Get question type icon
                 const getQuestionIcon = (type) => {
                     switch(type) {
@@ -691,7 +692,7 @@
                         default: return 'ph-question';
                     }
                 };
-                
+
                 questionCard.innerHTML = `
                     <div class="flex flex-col space-y-4">
                         <!-- Question Header -->
@@ -712,12 +713,12 @@
                                 <div class="text-xs text-[#797878] font-['DM_Sans']">completion</div>
                             </div>
                         </div>
-                        
+
                         <!-- Question Text -->
                         <div>
                             <h4 class="font-['DM_Sans'] text-[#1e1e1e] text-lg font-medium leading-relaxed">${question.text}</h4>
                         </div>
-                        
+
                         <!-- Stats Grid and Preview -->
                         <div class="flex flex-col lg:flex-row gap-6">
                             <!-- Stats Grid -->
@@ -743,14 +744,14 @@
                                     </div>
                                 </div>
                             </div>
-                            
+
                             <!-- Quick Preview -->
                             <div class="lg:w-64 bg-[#fef9ee] rounded-lg p-4">
                                 <div class="text-xs text-[#797878] font-['DM_Sans'] mb-3">Quick Preview</div>
                                 ${getQuestionPreview(question, responses)}
                             </div>
                         </div>
-                        
+
                         <!-- Action Button -->
                         <div class="flex justify-start">
                             <button onclick="viewQuestionDetails(${index})" class="bg-[#cc5500] text-white px-4 py-2 rounded-lg text-sm font-['DM_Sans'] hover:opacity-90 flex items-center gap-2">
@@ -760,7 +761,7 @@
                         </div>
                     </div>
                 `;
-                
+
                 container.appendChild(questionCard);
             });
         }

--- a/templates/voice.html
+++ b/templates/voice.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#cc5500">
+    <title>{{ form_title }} - Barmuda Forms</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body class="bg-[#fef5e0] h-screen flex flex-col">
+    {% set nav_type = 'voice' %}
+    {% include 'partials/nav.html' %}
+
+    <div class="flex-1 flex flex-col items-center justify-center space-y-6">
+        <div id="visualizer" class="w-32 h-32 rounded-full bg-gradient-to-br from-orange-400 to-pink-400 animate-pulse"></div>
+        <div class="space-x-4">
+            <button id="start-btn" class="px-4 py-2 bg-[#cc5500] text-white rounded-full">Start</button>
+            <button id="pause-btn" class="px-4 py-2 bg-gray-300 rounded-full">Pause</button>
+            <button id="end-btn" class="px-4 py-2 bg-red-500 text-white rounded-full">End</button>
+        </div>
+    </div>
+
+    <script>
+        window.AGENT_ID = "{{ agent_id }}";
+    </script>
+    <script src="/static/js/voice.js"></script>
+</body>
+</html>

--- a/voice_agent.py
+++ b/voice_agent.py
@@ -1,0 +1,26 @@
+import logging
+import os
+from typing import Dict
+
+import requests
+
+ELEVENLABS_API_KEY = os.environ.get("ELEVENLABS_API_KEY", "").strip()
+ELEVENLABS_API_BASE = os.environ.get("ELEVENLABS_API_BASE", "https://api.elevenlabs.io")
+
+
+def _headers() -> Dict[str, str]:
+    if not ELEVENLABS_API_KEY:
+        raise ValueError("ELEVENLABS_API_KEY not configured")
+    return {
+        "xi-api-key": ELEVENLABS_API_KEY,
+        "Content-Type": "application/json",
+    }
+
+
+def create_ephemeral_token(agent_id: str) -> Dict:
+    """Request a short-lived ElevenLabs token for WebRTC sessions."""
+    url = f"{ELEVENLABS_API_BASE}/v1/convai/token"
+    payload = {"agent_id": agent_id}
+    resp = requests.post(url, json=payload, headers=_headers(), timeout=10)
+    resp.raise_for_status()
+    return resp.json()


### PR DESCRIPTION
## Summary
- allow forms to specify chat or voice mode with voice settings
- add voice interview page and ElevenLabs token endpoint
- include response `mode` metadata and session mode tracking
- show `voice` or `chat` chip for each saved response

## Testing
- `pre-commit run --files app.py templates/responses.html` *(fails: ModuleNotFoundError: No module named 'chat_agent_v3')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'factory'; plus connection errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b3176cb424832790dc9f75f5d60d9d