### PR TITLE
feat: add configurable voice recognition language

### DIFF
--- a/static/js/voice.js
+++ b/static/js/voice.js
@@ -32,6 +32,7 @@ class VoiceConversation {
       this.conversation = new ServerVoiceConversation({
         voiceId: this.voiceId,
         formId: this.formId,
+        language: this.language,
         onConnect: () => this.onConnect(),
         onDisconnect: () => this.onDisconnect(),
         onMessage: (message) => this.onMessage(message),
@@ -395,7 +396,7 @@ class ServerVoiceConversation {
     
     this.recognition.continuous = true;
     this.recognition.interimResults = true;
-    this.recognition.lang = 'en-US'; // Could be dynamic based on form settings
+    this.recognition.lang = this.config.language || 'en-US'; // Use configured language or default
     
     this.recognition.onresult = (event) => {
       let interimTranscript = '';


### PR DESCRIPTION
## Summary
- allow VoiceConversation to pass language to ServerVoiceConversation
- default voice recognition language to configured language or `en-US`

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b455346e748327b735a32794b95113