### PR TITLE
feat: integrate elevenlabs voice tokens

### DIFF
--- a/voice_agent.py
+++ b/voice_agent.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 
@@ -17,24 +17,39 @@ def _headers() -> Dict[str, str]:
     }
 
 
-def create_ephemeral_token(voice_id: str, form_data: Dict = None) -> Dict:
-    """Request a short-lived ElevenLabs token for WebRTC voice sessions."""
-    # For MVP, return a mock token structure for testing
-    # In production, this would integrate with ElevenLabs Conversational AI
-    return {
-        "token": "mock_token_for_voice_testing",
-        "expires_in": 3600,
-        "voice_id": voice_id
-    }
+def create_ephemeral_token(voice_id: str, metadata: Optional[Dict] = None) -> Dict:
+    """Request a short-lived ElevenLabs token for WebRTC voice sessions.
+
+    ElevenLabs provides an endpoint for creating ephemeral conversation tokens
+    which are required when establishing a WebRTC session with their
+    Conversational AI SDK. This replaces the previous mocked token generation
+    used during early development.
+    """
+
+    url = f"{ELEVENLABS_API_BASE}/v1/convai/tokens"
+
+    payload: Dict[str, Dict] = {"voice_id": voice_id}
+    if metadata:
+        # Forward any metadata such as agent identifiers so it can be used by
+        # ElevenLabs when creating the token.
+        payload["metadata"] = metadata
+
+    response = requests.post(url, json=payload, headers=_headers())
+    response.raise_for_status()
+
+    data = response.json()
+    # Ensure voice_id is included so downstream callers have it available
+    data.setdefault("voice_id", voice_id)
+    return data
 
 
 def generate_speech(text: str, voice_id: str) -> bytes:
     """Generate speech using ElevenLabs TTS API"""
     if not ELEVENLABS_API_KEY:
         raise ValueError("ElevenLabs API key not configured")
-    
+
     url = f"{ELEVENLABS_API_BASE}/v1/text-to-speech/{voice_id}"
-    
+
     payload = {
         "text": text,
         "model_id": "eleven_multilingual_v2",
@@ -42,13 +57,13 @@ def generate_speech(text: str, voice_id: str) -> bytes:
             "stability": 0.5,
             "similarity_boost": 0.8,
             "style": 0.3,
-            "use_speaker_boost": True
-        }
+            "use_speaker_boost": True,
+        },
     }
-    
+
     response = requests.post(url, json=payload, headers=_headers())
     response.raise_for_status()
-    
+
     return response.content
 
 
@@ -56,9 +71,9 @@ def get_available_voices() -> Dict:
     """Get list of available ElevenLabs voices"""
     if not ELEVENLABS_API_KEY:
         return {"voices": []}
-    
+
     url = f"{ELEVENLABS_API_BASE}/v1/voices"
-    
+
     try:
         response = requests.get(url, headers=_headers())
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- replace mocked ElevenLabs token generator with real API request
- forward voice metadata in `/api/voice/token`
- pass ephemeral token to ElevenLabs SDK on client

## Testing
- `pre-commit run --files voice_agent.py app.py static/js/voice.js` *(fails: ModuleNotFoundError: No module named 'chat_agent_v3')*
- `pytest tests/test_voice_mode.py::test_voice_token_generation_security tests/test_voice_mode.py::test_voice_session_start_validation tests/test_voice_mode.py::test_voice_session_save_validation` *(fails: expected 404 but got 200)*

------
https://chatgpt.com/codex/tasks/task_e_68b455359f7083278cf60705832e955e